### PR TITLE
Add optional grounding for parameters and states

### DIFF
--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -49,7 +49,6 @@
           "output": ["I","I"],
           "properties": {
             "name": "Infection",
-            "grounding": {},
             "rate": {
               "expression": "S*I*beta",
               "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
@@ -62,7 +61,6 @@
           "output": ["R"],
           "properties": {
             "name": "Recovery",
-            "grounding": {},
             "rate": {
               "expression": "I*gamma",
               "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -8,7 +8,9 @@
         {
           "id": "S",
           "name": "Susceptible",
-          "grounding": {},
+          "grounding": {
+            "identifiers": {"ido": "0000514"}
+          },
           "initial":
           {
             "expression": "S0",
@@ -18,6 +20,9 @@
         {
           "id": "I",
           "name": "Infected",
+          "grounding": {
+            "identifiers": {"ido": "0000511"}
+          },
           "initial":
           {
             "expression": "I0",
@@ -27,6 +32,9 @@
         {
           "id": "R",
           "name": "Recovered",
+          "grounding": {
+            "identifiers": {"ido": "0000592"}
+          },
           "initial":
           {
             "expression": "R0",
@@ -68,7 +76,7 @@
           "description": "infection rate",
           "value": 0.027,
           "distribution": {
-            "type": "StndardUniform1",
+            "type": "StandardUniform1",
             "parameters": {
               "minimum": 0.026,
               "maximum": 0.028
@@ -78,6 +86,9 @@
         {
           "id": "gamma",
           "description": "recovery rate",
+          "grounding": {
+            "identifiers": {"askemo": "0000013"}
+          },
           "value": 0.14,
           "distribution": {
             "type": "StandardUniform1",

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -86,7 +86,7 @@
       "distribution": {
         "type": "object",
         "properties": {
-          "type": {"type": "string"},
+          "type": {"type": "object"},
           "parameters": {"type": "object"}
         },
         "required": ["type", "parameters"],

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -100,7 +100,7 @@
           "identifiers": {"type": "object"},
           "context": {"type": "object"}
         },
-        "required": ["identifiers", "context"],
+        "required": ["identifiers"],
         "additionalProperties": false
       }
     },

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -43,7 +43,8 @@
                 "id": {"type": "string"},
                 "description": {"type": "string"},
                 "value": {"type": "number"},
-                "distribution": {"$ref": "#/$defs/distribution"}
+                "distribution": {"$ref": "#/$defs/distribution"},
+                "grounding": {"type": "object"}
               },
               "required": ["id"]
             }

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -86,7 +86,7 @@
       "distribution": {
         "type": "object",
         "properties": {
-          "type": {"type": "object"},
+          "type": {"type": "string"},
           "parameters": {"type": "object"}
         },
         "required": ["type", "parameters"],
@@ -95,7 +95,7 @@
       "grounding": {
         "type": "object",
         "properties": {
-          "identifiers": {"type": "string"},
+          "identifiers": {"type": "object"},
           "context": {"type": "object"}
         },
         "required": ["identifiers", "context"],

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -17,6 +17,7 @@
               "properties": {
                 "id": {"type": "string"},
                 "name": {"type": "string"},
+                "grounding": {"$ref": "#/$defs/grounding"},
                 "initial": {"$ref": "#/$defs/initial"}
               },
               "required": ["id"]
@@ -30,6 +31,7 @@
                 "id": {"type": "string"},
                 "input": {"type": "array", "items": {"type": "string"}},
                 "output": {"type": "array", "items": {"type": "string"}},
+                "grounding": {"$ref": "#/$defs/grounding"},
                 "properties": {"$ref": "#/$defs/properties"}
               },
               "required": ["id", "input", "output"]
@@ -43,8 +45,8 @@
                 "id": {"type": "string"},
                 "description": {"type": "string"},
                 "value": {"type": "number"},
-                "distribution": {"$ref": "#/$defs/distribution"},
-                "grounding": {"$ref": "#/$defs/grounding"}
+                "grounding": {"$ref": "#/$defs/grounding"},
+                "distribution": {"$ref": "#/$defs/distribution"}
               },
               "required": ["id"]
             }
@@ -68,7 +70,7 @@
         "type": "object",
         "properties": {
           "name": {"type": "string"},
-          "grounding": {"type": "object"},
+          "grounding": {"$ref": "#/$defs/grounding"},
           "rate": {"$ref": "#/$defs/rate"}
         },
         "required": ["name", "rate"],

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -44,7 +44,7 @@
                 "description": {"type": "string"},
                 "value": {"type": "number"},
                 "distribution": {"$ref": "#/$defs/distribution"},
-                "grounding": {"type": "object"}
+                "grounding": {"$ref": "#/$defs/grounding"}
               },
               "required": ["id"]
             }
@@ -91,6 +91,15 @@
         },
         "required": ["type", "parameters"],
         "additionalProperties": true
+      },
+      "grounding": {
+        "type": "object",
+        "properties": {
+          "identifiers": {"type": "string"},
+          "context": {"type": "object"}
+        },
+        "required": ["identifiers", "context"],
+        "additionalProperties": false
       }
     },
     "additionalProperties": true,


### PR DESCRIPTION
This PR adds an optional grounding attribute for parameters and states. It also defines grounding as a reusable object in the schema with more details on its internal structure.