### PR TITLE
Add TA1 extractions, annotations, and metadata

### DIFF
--- a/base_schema.json
+++ b/base_schema.json
@@ -24,7 +24,7 @@
         "description": "(Optional) Information about the model that may be used during modification or execution of the model."
       },
       "metadata": {
-        "type": "object",
+        "type": "array",
         "description": "(Optional) Information not useful for execution of the model, but that may be useful to some consumer in the future. E.g. creation timestamp or source paper's author."
       }
     },

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -112,5 +112,36 @@
           "value": 0
         }
       ]
-    }
+    },
+    "metadata": [{
+      "id": "metadatum_1",
+      "type": "variable",
+      "refers_to_id": "S0",
+      "metadata": [
+        {
+          "type": "data_annotation",
+          "value": "1523330"
+        }
+      ],
+      "datasets": [
+        {
+          "id": "dataset_1",
+          "name": "population_by_state.csv",
+          "metadata": {
+            "url": "https://raw.githubusercontent.com/covid19data/examples/population_by_state.csv"
+          }
+        }
+      ],
+      "papers": [
+        {
+          "id": "paper_1",
+          "name": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
+          "doi": "10.1101/2021.10.08.21264595"
+        }
+      ],
+      "provenance": {
+        "type": "MIT annotation",
+        "value": "text, dataset, formula annotation (chunwei@mit.edu)"
+      }
+    }]
   }

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -113,35 +113,37 @@
         }
       ]
     },
-    "metadata": [{
-      "id": "metadatum_1",
-      "type": "variable",
-      "refers_to_id": "S0",
-      "metadata": [
-        {
-          "type": "data_annotation",
-          "value": "1523330"
-        }
-      ],
-      "datasets": [
-        {
-          "id": "dataset_1",
-          "name": "population_by_state.csv",
-          "metadata": {
-            "url": "https://raw.githubusercontent.com/covid19data/examples/population_by_state.csv"
+    "metadata": [
+      {
+        "id": "metadatum_1",
+        "type": "variable",
+        "refers_to_id": "S0",
+        "metadata": [
+          {
+            "type": "data_annotation",
+            "value": "1523330"
           }
+        ],
+        "datasets": [
+          {
+            "id": "dataset_1",
+            "name": "population_by_state.csv",
+            "metadata": {
+              "url": "https://raw.githubusercontent.com/covid19data/examples/population_by_state.csv"
+            }
+          }
+        ],
+        "papers": [
+          {
+            "id": "paper_1",
+            "name": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
+            "doi": "10.1101/2021.10.08.21264595"
+          }
+        ],
+        "provenance": {
+          "type": "MIT annotation",
+          "value": "text, dataset, formula annotation (chunwei@mit.edu)"
         }
-      ],
-      "papers": [
-        {
-          "id": "paper_1",
-          "name": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
-          "doi": "10.1101/2021.10.08.21264595"
-        }
-      ],
-      "provenance": {
-        "type": "MIT annotation",
-        "value": "text, dataset, formula annotation (chunwei@mit.edu)"
       }
-    }]
+    ]
   }

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -54,7 +54,43 @@
         },
         "additionalProperties": false,
         "required": ["states", "transitions", "parameters"]
-      }
+      },
+    "metadata": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "refers_to_id": {"type": "string"},
+          "name": {"type": "string"},
+          "provenance": {"$ref": "#/$defs/provenance"},
+          "metadata": {
+            "type": "array", 
+            "items": {
+                "type": "object",
+                "$ref": "#/$defs/metadatum"
+              }
+            },
+          "datasets": {
+            "type": "array", 
+            "items": {
+                "type": "object",
+                "$ref": "#/$defs/dataset"
+              }
+            },
+          "papers": {
+            "type": "array", 
+            "items": {
+                "type": "object",
+                "$ref": "#/$defs/paper"
+              }
+          },            
+          "grounding": {"$ref": "#/$defs/grounding"}
+          },
+          "additionalProperties": true,
+          "required": ["id", "refers_to_id", "metadata"]          
+        }
+      }      
     },
     "$defs": {
       "initial": {
@@ -102,7 +138,53 @@
         },
         "required": ["identifiers"],
         "additionalProperties": false
-      }
+      },
+      "provenance": {
+        "type": "object",
+        "properties": {
+          "type": {"type": "string"},
+          "value": {"type": "string"}
+        },
+        "required": ["type", "value"],
+        "additionalProperties": false
+      },      
+      "metadatum": {
+        "type": "object",
+        "properties": {
+          "type": {"type": "string"},
+          "value": {"type": "string"}
+        },
+        "required": ["type", "value"],
+        "additionalProperties": false
+      },
+      "dataset": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"},
+          "column": {"type": "string"},
+          "metadata": {"type": "object"}
+        },
+        "required": ["id"],
+        "additionalProperties": false
+      },
+      "paper": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "doi": {"type": "string"},          
+          "name": {"type": "string"},
+          "equations": {
+            "type": "array", 
+            "items": {
+              "type": "object"
+              }
+          },
+          "metadata": {"type": "object"}
+        },
+        "required": ["id", "doi"],
+        "additionalProperties": false
+      }         
     },
     "additionalProperties": true,
     "required": ["name", "description", "schema", "model"]


### PR DESCRIPTION
# What's New

This PR implements the `metadata` field from the `base_schema.json` explicitly in the `petrinet_schema.json`. It includes a best effort to faithfully capture the examples provided in the [TA1 extraction presentation](https://docs.google.com/presentation/d/1MmNN-fTu04xKNp4jY4GCUjahmBQfb62uhcmdxhpNZ5A/edit#slide=id.g20a18e1bb32_0_35) from @Tranway1 and @enoriega as well as a metadatum to item `id` mapping proposed in the [TA1 metadata document](https://docs.google.com/document/d/1hCBn0BNGAgbvJjajEEl2yIGNAB2x_e6DibDkly7gQog/edit#heading=h.8hs8ezheo867) from @cl4yton.

In essence, `metadata` is now an array of annotations or extractions produced by TA1. Each metadatum has its own `id` as well as a `refers_to_id` which should be one of the `ids` of the `states`, `transitions`, or `parameters`. 

It includes a defined `metadatum` spec as well as specs for extractions from `datasets` and `papers`.

@Tranway1 @enoriega @cl4yton I am pretty sure that I did _**not get this 100% correct**_ and would love it if you all could help me make this true to your current spec and intent.

## Considerations

I made an effort to coerce the `refers_to_id` to be explicitly one of the `states.ids`, `parameter.ids` or `transition.ids` but this proved to be pretty clunky in JSON schema. It _might_ be possible, but requires some backflips. We have the same issue across the board (e.g. `transitions.input` should be constrained too) so I think this is fine.

> In the future, we may want to pull the `metadata` spec out into a `common.json` definition file as suggested by @bgyori since it should be consistent across modeling frameworks. This would also simplify the `petrinet_schema.json` to just include it's core functionality.