### PR TITLE
Added the metadata schema as a standalone file

### DIFF
--- a/base_schema.json
+++ b/base_schema.json
@@ -24,7 +24,7 @@
         "description": "(Optional) Information about the model that may be used during modification or execution of the model."
       },
       "metadata": {
-        "type": "array",
+        "type": "object",
         "description": "(Optional) Information not useful for execution of the model, but that may be useful to some consumer in the future. E.g. creation timestamp or source paper's author."
       }
     },

--- a/metadata_schema.json
+++ b/metadata_schema.json
@@ -1,0 +1,353 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the model."
+    },
+    "description": {
+      "type": "string",
+      "description": "A description of the model."
+    },
+    "schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI of a JSON schema document that describes the model stored in the 'model' parameter."
+    },
+    "model": {
+      "type": "object",
+      "description": "JSON representation of a model. This should contain everything needed to fully run the model, including all rates/initial parameters/distributions/etc."
+    },
+    "properties": {
+      "type": "object",
+      "description": "(Optional) Information about the model that may be used during modification or execution of the model."
+    },
+    "metadata": {
+      "title": "ExtractionsCollection",
+      "description": "Represents a collection of extractions ",
+      "type": "object",
+      "properties": {
+        "variable_statements": {
+          "title": "Variable Statements",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VariableStatement"
+          }
+        }
+      },
+      "required": [
+        "variable_statements"
+      ],
+      "$id": "#/definitions/ExtractionsCollection",
+      "definitions": {
+        "VariableMetadata": {
+          "title": "VariableMetadata",
+          "description": "Represents some metadata about a variable instance ",
+          "type": "object",
+          "properties": {
+            "type": {
+              "title": "Type",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "$id": "#/definitions/VariableMetadata"
+        },
+        "DKGConcept": {
+          "title": "DKGConcept",
+          "description": "Represents a grounding to a DKG concept ",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "type": "string"
+            },
+            "score": {
+              "title": "Score",
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "$id": "#/definitions/DKGConcept"
+        },
+        "Dataset": {
+          "title": "Dataset",
+          "description": "Represents a dataset ",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "type": "string"
+            },
+            "metadata": {
+              "title": "Metadata",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "name"
+          ],
+          "$id": "#/definitions/Dataset"
+        },
+        "DataColumn": {
+          "title": "DataColumn",
+          "description": "Represents a column of a dataset ",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "type": "string"
+            },
+            "dataset": {
+              "$ref": "#/definitions/Dataset"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "dataset"
+          ],
+          "$id": "#/definitions/DataColumn"
+        },
+        "Paper": {
+          "title": "Paper",
+          "description": "Represents a paper from which an extraction comes ",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "file_directory": {
+              "title": "File Directory",
+              "type": "string"
+            },
+            "doi": {
+              "title": "Doi",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "file_directory",
+            "doi"
+          ],
+          "$id": "#/definitions/Paper"
+        },
+        "Equation": {
+          "title": "Equation",
+          "description": "Represents an equation extraction ",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "text": {
+              "title": "Text",
+              "type": "string"
+            },
+            "image": {
+              "title": "Image",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "text"
+          ],
+          "$id": "#/definitions/Equation"
+        },
+        "Variable": {
+          "title": "Variable",
+          "description": "Represents an extracted variable/identifier ",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "name": {
+              "title": "Name",
+              "type": "string"
+            },
+            "metadata": {
+              "title": "Metadata",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/VariableMetadata"
+              }
+            },
+            "dkg_groundings": {
+              "title": "Dkg Groundings",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DKGConcept"
+              }
+            },
+            "column": {
+              "title": "Column",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/DataColumn"
+              }
+            },
+            "paper": {
+              "$ref": "#/definitions/Paper"
+            },
+            "equations": {
+              "title": "Equations",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Equation"
+              }
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "dkg_groundings"
+          ],
+          "$id": "#/definitions/Variable"
+        },
+        "StatementValueType": {
+          "title": "StatementValueType",
+          "description": "Represents the type of the statement ",
+          "enum": [
+            "description",
+            "value",
+            "unit",
+            "unit_and_value",
+            "misc",
+            "<class 'askem_extractions.data_model.statement_value_type.StatementValueType.Config'>"
+          ],
+          "type": "string",
+          "$id": "#/definitions/StatementValueType"
+        },
+        "StatementValue": {
+          "title": "StatementValue",
+          "description": "Represents the contents of a statement about a variable ",
+          "type": "object",
+          "properties": {
+            "value": {
+              "title": "Value",
+              "type": "string"
+            },
+            "type": {
+              "$ref": "#/definitions/StatementValueType"
+            },
+            "dkg_grounding": {
+              "$ref": "#/definitions/DKGConcept"
+            }
+          },
+          "required": [
+            "value",
+            "type"
+          ],
+          "$id": "#/definitions/StatementValue"
+        },
+        "VariableStatementMetadata": {
+          "title": "VariableStatementMetadata",
+          "description": "Metadata associated to a specific variable statement ",
+          "type": "object",
+          "properties": {
+            "type": {
+              "title": "Type",
+              "type": "string"
+            },
+            "value": {
+              "title": "Value",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "value"
+          ],
+          "$id": "#/definitions/VariableStatementMetadata"
+        },
+        "ProvenanceInfo": {
+          "title": "ProvenanceInfo",
+          "description": "Describes the provenance of an extraction ",
+          "type": "object",
+          "properties": {
+            "method": {
+              "title": "Method",
+              "type": "string"
+            },
+            "description": {
+              "title": "Description",
+              "type": "string"
+            }
+          },
+          "required": [
+            "method",
+            "description"
+          ],
+          "$id": "#/definitions/ProvenanceInfo"
+        },
+        "VariableStatement": {
+          "title": "VariableStatement",
+          "description": "Represents a statement about a variable ",
+          "type": "object",
+          "properties": {
+            "id": {
+              "title": "Id",
+              "type": "string"
+            },
+            "variable": {
+              "$ref": "#/definitions/Variable"
+            },
+            "value": {
+              "$ref": "#/definitions/StatementValue"
+            },
+            "metadata": {
+              "title": "Metadata",
+              "default": [],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/VariableStatementMetadata"
+              }
+            },
+            "provenance": {
+              "$ref": "#/definitions/ProvenanceInfo"
+            }
+          },
+          "required": [
+            "id",
+            "variable"
+          ],
+          "$id": "#/definitions/VariableStatement"
+        }
+      }
+    }
+  },
+  "required": ["name", "description", "schema", "model"]
+}  

--- a/metadata_schema.json
+++ b/metadata_schema.json
@@ -23,7 +23,7 @@
       "type": "object",
       "description": "(Optional) Information about the model that may be used during modification or execution of the model."
     },
-    "metadata": {
+    "metadata":{
       "title": "ExtractionsCollection",
       "description": "Represents a collection of extractions ",
       "type": "object",
@@ -237,20 +237,6 @@
           ],
           "$id": "#/definitions/Variable"
         },
-        "StatementValueType": {
-          "title": "StatementValueType",
-          "description": "Represents the type of the statement ",
-          "enum": [
-            "description",
-            "value",
-            "unit",
-            "unit_and_value",
-            "misc",
-            "<class 'askem_extractions.data_model.statement_value_type.StatementValueType.Config'>"
-          ],
-          "type": "string",
-          "$id": "#/definitions/StatementValueType"
-        },
         "StatementValue": {
           "title": "StatementValue",
           "description": "Represents the contents of a statement about a variable ",
@@ -261,7 +247,8 @@
               "type": "string"
             },
             "type": {
-              "$ref": "#/definitions/StatementValueType"
+              "title": "Type",
+              "type": "string"
             },
             "dkg_grounding": {
               "$ref": "#/definitions/DKGConcept"

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -113,37 +113,60 @@
         }
       ]
     },
-    "metadata": [
-      {
-        "id": "metadatum_1",
-        "type": "variable",
-        "refers_to_id": "S0",
-        "metadata": [
-          {
-            "type": "data_annotation",
-            "value": "1523330"
-          }
-        ],
-        "datasets": [
-          {
-            "id": "dataset_1",
-            "name": "population_by_state.csv",
-            "metadata": {
-              "url": "https://raw.githubusercontent.com/covid19data/examples/population_by_state.csv"
+    "metadata": {
+      "variable_statements": [
+        {
+          "id": "v0",
+          "variable": {
+            "id": "v0",
+            "name": "VE",
+            "metadata": [
+              {
+                "type": "text_annotation",
+                "value": " Vaccine Effectiveness"
+              },
+              {
+                "type": "text_annotation",
+                "value": " Vaccine Effectiveness"
+              }
+            ],
+            "dkg_groundings": [],
+            "column": [
+              {
+                "id": "9-2",
+                "name": "new_persons_vaccinated",
+                "dataset": {
+                  "id": "9",
+                  "name": "usa-vaccinations.csv",
+                  "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+                }
+              },
+              {
+                "id": "9-3",
+                "name": "cumulative_persons_vaccinated",
+                "dataset": {
+                  "id": "9",
+                  "name": "usa-vaccinations.csv",
+                  "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+                }
+              }
+            ],
+            "paper": {
+              "id": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
+              "file_directory": "https://www.medrxiv.org/content/10.1101/2021.10.08.21264595v1",
+              "doi": "10.1101/2021.10.08.21264595"
+            },
+            "equations": []
+          },
+
+          "metadata": []
+          ,
+          "provenance":
+            {
+              "method": "MIT annotation",
+              "description": "text, dataset, formula annotation (chunwei@mit.edu)"
             }
-          }
-        ],
-        "papers": [
-          {
-            "id": "paper_1",
-            "name": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
-            "doi": "10.1101/2021.10.08.21264595"
-          }
-        ],
-        "provenance": {
-          "type": "MIT annotation",
-          "value": "text, dataset, formula annotation (chunwei@mit.edu)"
         }
-      }
-    ]
+      ]
+    }
   }

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -55,42 +55,10 @@
         "additionalProperties": false,
         "required": ["states", "transitions", "parameters"]
       },
-    "metadata": {
-      "type": "array",
-      "items": {
+      "metadata": {
         "type": "object",
-        "properties": {
-          "id": {"type": "string"},
-          "refers_to_id": {"type": "string"},
-          "name": {"type": "string"},
-          "provenance": {"$ref": "#/$defs/provenance"},
-          "metadata": {
-            "type": "array", 
-            "items": {
-                "type": "object",
-                "$ref": "#/$defs/metadatum"
-              }
-            },
-          "datasets": {
-            "type": "array", 
-            "items": {
-                "type": "object",
-                "$ref": "#/$defs/dataset"
-              }
-            },
-          "papers": {
-            "type": "array", 
-            "items": {
-                "type": "object",
-                "$ref": "#/$defs/paper"
-              }
-          },            
-          "grounding": {"$ref": "#/$defs/grounding"}
-          },
-          "additionalProperties": true,
-          "required": ["id", "refers_to_id", "metadata"]          
-        }
-      }      
+        "description": "(Optional) Information not useful for execution of the model, but that may be useful to some consumer in the future. E.g. creation timestamp or source paper's author."
+      }
     },
     "$defs": {
       "initial": {

--- a/validation/test.js
+++ b/validation/test.js
@@ -10,6 +10,7 @@ addFormats(ajv);
 const testPath = process.argv.length > 2 ? process.argv[2] : "../";
 
 const baseSchemaFile = `${testPath}base_schema.json`;
+const metadataSchemaFile = `${testPath}metadata_schema.json`
 const schemaFiles = globSync(`${testPath}*/*.json`);
 
 const validate = (schemaFile, objectFile) => {
@@ -32,9 +33,10 @@ for (let schemaFile of schemaFiles) {
     for (let exampleFile of exampleFiles) {
         testCount++;
         const baseSchemaPassed = validate(baseSchemaFile, exampleFile);
+        const metadataSchemaPassed = validate(metadataSchemaFile, exampleFile);
         const filePassed = validate(schemaFile, exampleFile);
         // The validation is true only if everything passes all the times. One failure and you're out!
-        const testPassed = baseSchemaPassed & filePassed;
+        const testPassed = baseSchemaPassed & metadataSchemaPassed & filePassed;
         if (testPassed) {
             passCount++;
         } else {


### PR DESCRIPTION
Starting from the `extractions` branch, updated the metadata schema to reflect the [ER model designed in the Miro board](https://miro.com/app/board/uXjVMZvPN6o=/) and implemented in the [GitHub repository](https://github.com/ml4ai/ASKEM-TA1-DataModel).

The metadata schema is automatically exported from Pydantic, and it is substantial, so I factored it out into its own file (`metadata_schema.json`). This will allow us to drop in a replacement if the ER model changes with minimal modifications to the rest of the code in this repository.  This also generalizes the metadata beyond petri-nets to any abstract representation of the model.

We updated the test data file `sir.json` to add a metadata entry compliant with the schema and updated the validator code to be aware of the new schema file.