### PR TITLE
Refactor Petrinet schema and example to separate semantics

### DIFF
--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -12,10 +12,6 @@
           "identifiers": {
             "ido": "0000514"
           }
-        },
-        "initial": {
-          "expression": "S0",
-          "expression_mathml": "<ci>S0</ci>"
         }
       },
       {
@@ -25,10 +21,6 @@
           "identifiers": {
             "ido": "0000511"
           }
-        },
-        "initial": {
-          "expression": "I0",
-          "expression_mathml": "<ci>I0</ci>"
         }
       },
       {
@@ -38,10 +30,6 @@
           "identifiers": {
             "ido": "0000592"
           }
-        },
-        "initial": {
-          "expression": "R0",
-          "expression_mathml": "<ci>R0</ci>"
         }
       }
     ],
@@ -57,11 +45,7 @@
           "I"
         ],
         "properties": {
-          "name": "Infection",
-          "rate": {
-            "expression": "S*I*beta",
-            "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
-          }
+          "name": "Infection"
         }
       },
       {
@@ -73,60 +57,89 @@
           "R"
         ],
         "properties": {
-          "name": "Recovery",
-          "rate": {
-            "expression": "I*gamma",
-            "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
-          }
+          "name": "Recovery"
         }
-      }
-    ],
-    "parameters": [
-      {
-        "id": "beta",
-        "description": "infection rate",
-        "value": 0.027,
-        "distribution": {
-          "type": "StandardUniform1",
-          "parameters": {
-            "minimum": 0.026,
-            "maximum": 0.028
-          }
-        }
-      },
-      {
-        "id": "gamma",
-        "description": "recovery rate",
-        "grounding": {
-          "identifiers": {
-            "askemo": "0000013"
-          }
-        },
-        "value": 0.14,
-        "distribution": {
-          "type": "StandardUniform1",
-          "parameters": {
-            "minimum": 0.1,
-            "maximum": 0.18
-          }
-        }
-      },
-      {
-        "id": "S0",
-        "description": "Total susceptible population at timestep 0",
-        "value": 1000
-      },
-      {
-        "id": "I0",
-        "description": "Total infected population at timestep 0",
-        "value": 1
-      },
-      {
-        "id": "R0",
-        "description": "Total recovered population at timestep 0",
-        "value": 0
       }
     ]
+  },
+  "semantics": {
+    "ode": {
+      "rates": [
+        {
+          "target": "inf",
+          "expression": "S*I*beta",
+          "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
+        },
+        {
+          "target": "rec",
+          "expression": "I*gamma",
+          "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
+        }
+      ],
+      "initials": [
+        {
+          "target": "S",
+          "expression": "S0",
+          "expression_mathml": "<ci>S0</ci>"
+        },
+        {
+          "target": "I",
+          "expression": "I0",
+          "expression_mathml": "<ci>I0</ci>"
+        },
+        {
+          "target": "R",
+          "expression": "R0",
+          "expression_mathml": "<ci>R0</ci>"
+        }
+      ],
+      "parameters": [
+        {
+          "id": "beta",
+          "description": "infection rate",
+          "value": 0.027,
+          "distribution": {
+            "type": "StandardUniform1",
+            "parameters": {
+              "minimum": 0.026,
+              "maximum": 0.028
+            }
+          }
+        },
+        {
+          "id": "gamma",
+          "description": "recovery rate",
+          "grounding": {
+            "identifiers": {
+              "askemo": "0000013"
+            }
+          },
+          "value": 0.14,
+          "distribution": {
+            "type": "StandardUniform1",
+            "parameters": {
+              "minimum": 0.1,
+              "maximum": 0.18
+            }
+          }
+        },
+        {
+          "id": "S0",
+          "description": "Total susceptible population at timestep 0",
+          "value": 1000
+        },
+        {
+          "id": "I0",
+          "description": "Total infected population at timestep 0",
+          "value": 1
+        },
+        {
+          "id": "R0",
+          "description": "Total recovered population at timestep 0",
+          "value": 0
+        }
+      ]
+    }
   },
   "metadata": {
     "processed_at": 1682964953,

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -86,65 +86,8 @@
       "type": "object",
       "description": "Information specific to a given semantics (e.g., ODEs) associated with a model.",
       "properties": {
-        "rates": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "target": {
-                "type": "string"
-              },
-              "expression": {
-                "type": "string"
-              },
-              "expression_mathml": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "initials": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "target": {
-                "type": "string"
-              },
-              "expression": {
-                "type": "string"
-              },
-              "expression_mathml": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "parameters": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "description": {
-                "type": "string"
-              },
-              "value": {
-                "type": "number"
-              },
-              "grounding": {
-                "$ref": "#/$defs/grounding"
-              },
-              "distribution": {
-                "$ref": "#/$defs/distribution"
-              }
-            },
-            "required": [
-              "id"
-            ]
-          }
+        "ode": {
+          "$ref": "#/$defs/odeSemantics"
         }
       }
     },
@@ -280,6 +223,71 @@
         "doi"
       ],
       "additionalProperties": false
+    },
+    "odeSemantics": {
+      "type": "object",
+      "properties": {
+        "rates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "string"
+              },
+              "expression": {
+                "type": "string"
+              },
+              "expression_mathml": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "initials": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "string"
+              },
+              "expression": {
+                "type": "string"
+              },
+              "expression_mathml": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              },
+              "grounding": {
+                "$ref": "#/$defs/grounding"
+              },
+              "distribution": {
+                "$ref": "#/$defs/distribution"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          }
+        }
+      }
     }
   },
   "additionalProperties": true,

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -34,9 +34,6 @@
               },
               "grounding": {
                 "$ref": "#/$defs/grounding"
-              },
-              "initial": {
-                "$ref": "#/$defs/initial"
               }
             },
             "required": [
@@ -77,6 +74,51 @@
               "output"
             ]
           }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "states",
+        "transitions"
+      ]
+    },
+    "semantics": {
+      "type": "object",
+      "description": "Information specific to a given semantics (e.g., ODEs) associated with a model.",
+      "properties": {
+        "rates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "string"
+              },
+              "expression": {
+                "type": "string"
+              },
+              "expression_mathml": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "initials": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "string"
+              },
+              "expression": {
+                "type": "string"
+              },
+              "expression_mathml": {
+                "type": "string"
+              }
+            }
+          }
         },
         "parameters": {
           "type": "array",
@@ -104,13 +146,7 @@
             ]
           }
         }
-      },
-      "additionalProperties": false,
-      "required": [
-        "states",
-        "transitions",
-        "parameters"
-      ]
+      }
     },
     "metadata": {
       "type": "object",
@@ -118,22 +154,6 @@
     }
   },
   "$defs": {
-    "initial": {
-      "type": "object",
-      "properties": {
-        "expression": {
-          "type": "string"
-        },
-        "expression_mathml": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "expression",
-        "expression_mathml"
-      ],
-      "additionalProperties": true
-    },
     "properties": {
       "type": "object",
       "properties": {
@@ -142,30 +162,10 @@
         },
         "grounding": {
           "$ref": "#/$defs/grounding"
-        },
-        "rate": {
-          "$ref": "#/$defs/rate"
         }
       },
       "required": [
-        "name",
-        "rate"
-      ],
-      "additionalProperties": true
-    },
-    "rate": {
-      "type": "object",
-      "properties": {
-        "expression": {
-          "type": "string"
-        },
-        "expression_mathml": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "expression",
-        "expression_mathml"
+        "name"
       ],
       "additionalProperties": true
     },


### PR DESCRIPTION
This PR refactors the schema and example for the `petrinet` framework to separate out semantics from the model. The diff is larger than expected due to the issue described in #23.