### PR TITLE
Standardize JSON formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# top-most EditorConfig file
+root = true
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/validate_examples.yml
+++ b/.github/workflows/validate_examples.yml
@@ -15,4 +15,7 @@ jobs:
           npm test
   json-formatting:
     name: EditorConfig-Action
-    uses: zbeekman/EditorConfig-Action@v1.1.1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: zbeekman/EditorConfig-Action@v1.1.1

--- a/.github/workflows/validate_examples.yml
+++ b/.github/workflows/validate_examples.yml
@@ -13,3 +13,6 @@ jobs:
           cd validation
           npm ci
           npm test
+  json-formatting:
+    name: EditorConfig-Action
+    uses: zbeekman/EditorConfig-Action@v1.1.1

--- a/.github/workflows/validate_examples.yml
+++ b/.github/workflows/validate_examples.yml
@@ -14,8 +14,9 @@ jobs:
           npm ci
           npm test
   json-formatting:
-    name: EditorConfig-Action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: zbeekman/EditorConfig-Action@v1.1.1
+      - uses: actions/checkout@v2
+      - uses: editorconfig-checker/action-editorconfig-checker@main
+      - run: editorconfig-checker
+

--- a/base_schema.json
+++ b/base_schema.json
@@ -1,32 +1,37 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-      "name": {
-        "type": "string",
-        "description": "Name of the model."
-      },
-      "description": {
-        "type": "string",
-        "description": "A description of the model."
-      },
-      "schema": {
-        "type": "string",
-        "format": "uri",
-        "description": "URI of a JSON schema document that describes the model stored in the 'model' parameter."
-      },
-      "model": {
-        "type": "object",
-        "description": "JSON representation of a model. This should contain everything needed to fully run the model, including all rates/initial parameters/distributions/etc."
-      },
-      "properties": {
-        "type": "object",
-        "description": "(Optional) Information about the model that may be used during modification or execution of the model."
-      },
-      "metadata": {
-        "type": "object",
-        "description": "(Optional) Information not useful for execution of the model, but that may be useful to some consumer in the future. E.g. creation timestamp or source paper's author."
-      }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the model."
     },
-    "required": ["name", "description", "schema", "model"]
-  }
+    "description": {
+      "type": "string",
+      "description": "A description of the model."
+    },
+    "schema": {
+      "type": "string",
+      "format": "uri",
+      "description": "URI of a JSON schema document that describes the model stored in the 'model' parameter."
+    },
+    "model": {
+      "type": "object",
+      "description": "JSON representation of a model. This should contain everything needed to fully run the model, including all rates/initial parameters/distributions/etc."
+    },
+    "properties": {
+      "type": "object",
+      "description": "(Optional) Information about the model that may be used during modification or execution of the model."
+    },
+    "metadata": {
+      "type": "object",
+      "description": "(Optional) Information not useful for execution of the model, but that may be useful to some consumer in the future. E.g. creation timestamp or source paper's author."
+    }
+  },
+  "required": [
+    "name",
+    "description",
+    "schema",
+    "model"
+  ]
+}

--- a/metadata_schema.json
+++ b/metadata_schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "metadata":{
+    "metadata": {
       "title": "ExtractionsCollection",
       "description": "Represents a collection of extractions ",
       "type": "object",
@@ -314,4 +314,4 @@
     }
   },
   "required": []
-}  
+}

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -1,174 +1,186 @@
 {
-    "name": "SIR Model",
-    "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
-    "description": "SIR model created by Ben, Micah, Brandon",
-    "model_version": "0.1",
-    "model": {
-      "states": [
-        {
-          "id": "S",
-          "name": "Susceptible",
-          "grounding": {
-            "identifiers": {"ido": "0000514"}
-          },
-          "initial":
-          {
-            "expression": "S0",
-            "expression_mathml": "<ci>S0</ci>"
+  "name": "SIR Model",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
+  "description": "SIR model created by Ben, Micah, Brandon",
+  "model_version": "0.1",
+  "model": {
+    "states": [
+      {
+        "id": "S",
+        "name": "Susceptible",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000514"
           }
         },
-        {
-          "id": "I",
-          "name": "Infected",
-          "grounding": {
-            "identifiers": {"ido": "0000511"}
-          },
-          "initial":
-          {
-            "expression": "I0",
-            "expression_mathml": "<ci>I0</ci>"
+        "initial": {
+          "expression": "S0",
+          "expression_mathml": "<ci>S0</ci>"
+        }
+      },
+      {
+        "id": "I",
+        "name": "Infected",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000511"
           }
         },
-        {
-          "id": "R",
-          "name": "Recovered",
-          "grounding": {
-            "identifiers": {"ido": "0000592"}
-          },
-          "initial":
-          {
-            "expression": "R0",
-            "expression_mathml": "<ci>R0</ci>"
+        "initial": {
+          "expression": "I0",
+          "expression_mathml": "<ci>I0</ci>"
+        }
+      },
+      {
+        "id": "R",
+        "name": "Recovered",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000592"
+          }
+        },
+        "initial": {
+          "expression": "R0",
+          "expression_mathml": "<ci>R0</ci>"
+        }
+      }
+    ],
+    "transitions": [
+      {
+        "id": "inf",
+        "input": [
+          "S",
+          "I"
+        ],
+        "output": [
+          "I",
+          "I"
+        ],
+        "properties": {
+          "name": "Infection",
+          "rate": {
+            "expression": "S*I*beta",
+            "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
           }
         }
-      ],
-      "transitions": [
-        {
-          "id": "inf",
-          "input": ["S","I"],
-          "output": ["I","I"],
-          "properties": {
-            "name": "Infection",
-            "rate": {
-              "expression": "S*I*beta",
-              "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
-            }
-          }
-        },
-        {
-          "id": "rec",
-          "input": ["I"],
-          "output": ["R"],
-          "properties": {
-            "name": "Recovery",
-            "rate": {
-              "expression": "I*gamma",
-              "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
-            }
+      },
+      {
+        "id": "rec",
+        "input": [
+          "I"
+        ],
+        "output": [
+          "R"
+        ],
+        "properties": {
+          "name": "Recovery",
+          "rate": {
+            "expression": "I*gamma",
+            "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
           }
         }
-      ],
-      "parameters": [
-        {
-          "id": "beta",
-          "description": "infection rate",
-          "value": 0.027,
-          "distribution": {
-            "type": "StandardUniform1",
-            "parameters": {
-              "minimum": 0.026,
-              "maximum": 0.028
-            }
+      }
+    ],
+    "parameters": [
+      {
+        "id": "beta",
+        "description": "infection rate",
+        "value": 0.027,
+        "distribution": {
+          "type": "StandardUniform1",
+          "parameters": {
+            "minimum": 0.026,
+            "maximum": 0.028
           }
-        },
-        {
-          "id": "gamma",
-          "description": "recovery rate",
-          "grounding": {
-            "identifiers": {"askemo": "0000013"}
-          },
-          "value": 0.14,
-          "distribution": {
-            "type": "StandardUniform1",
-            "parameters": {
-              "minimum": 0.1,
-              "maximum": 0.18
-            }
-          }
-        },
-        {
-          "id": "S0",
-          "description": "Total susceptible population at timestep 0",
-          "value": 1000
-        },
-        {
-          "id": "I0",
-          "description": "Total infected population at timestep 0",
-          "value": 1
-        },
-        {
-          "id": "R0",
-          "description": "Total recovered population at timestep 0",
-          "value": 0
         }
-      ]
-    },
-    "metadata": {
-      "processed_at": 1682964953,
-      "processed_by": "mit:process-node1",
-      "variable_statements": [
-        {
+      },
+      {
+        "id": "gamma",
+        "description": "recovery rate",
+        "grounding": {
+          "identifiers": {
+            "askemo": "0000013"
+          }
+        },
+        "value": 0.14,
+        "distribution": {
+          "type": "StandardUniform1",
+          "parameters": {
+            "minimum": 0.1,
+            "maximum": 0.18
+          }
+        }
+      },
+      {
+        "id": "S0",
+        "description": "Total susceptible population at timestep 0",
+        "value": 1000
+      },
+      {
+        "id": "I0",
+        "description": "Total infected population at timestep 0",
+        "value": 1
+      },
+      {
+        "id": "R0",
+        "description": "Total recovered population at timestep 0",
+        "value": 0
+      }
+    ]
+  },
+  "metadata": {
+    "processed_at": 1682964953,
+    "processed_by": "mit:process-node1",
+    "variable_statements": [
+      {
+        "id": "v0",
+        "variable": {
           "id": "v0",
-          "variable": {
-            "id": "v0",
-            "name": "VE",
-            "metadata": [
-              {
-                "type": "text_annotation",
-                "value": " Vaccine Effectiveness"
-              },
-              {
-                "type": "text_annotation",
-                "value": " Vaccine Effectiveness"
-              }
-            ],
-            "dkg_groundings": [],
-            "column": [
-              {
-                "id": "9-2",
-                "name": "new_persons_vaccinated",
-                "dataset": {
-                  "id": "9",
-                  "name": "usa-vaccinations.csv",
-                  "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
-                }
-              },
-              {
-                "id": "9-3",
-                "name": "cumulative_persons_vaccinated",
-                "dataset": {
-                  "id": "9",
-                  "name": "usa-vaccinations.csv",
-                  "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
-                }
-              }
-            ],
-            "paper": {
-              "id": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
-              "file_directory": "https://www.medrxiv.org/content/10.1101/2021.10.08.21264595v1",
-              "doi": "10.1101/2021.10.08.21264595"
-            },
-            "equations": []
-          },
-
-          "metadata": []
-          ,
-          "provenance":
+          "name": "VE",
+          "metadata": [
             {
-              "method": "MIT annotation",
-              "description": "text, dataset, formula annotation (chunwei@mit.edu)"
+              "type": "text_annotation",
+              "value": " Vaccine Effectiveness"
+            },
+            {
+              "type": "text_annotation",
+              "value": " Vaccine Effectiveness"
             }
+          ],
+          "dkg_groundings": [],
+          "column": [
+            {
+              "id": "9-2",
+              "name": "new_persons_vaccinated",
+              "dataset": {
+                "id": "9",
+                "name": "usa-vaccinations.csv",
+                "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+              }
+            },
+            {
+              "id": "9-3",
+              "name": "cumulative_persons_vaccinated",
+              "dataset": {
+                "id": "9",
+                "name": "usa-vaccinations.csv",
+                "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+              }
+            }
+          ],
+          "paper": {
+            "id": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
+            "file_directory": "https://www.medrxiv.org/content/10.1101/2021.10.08.21264595v1",
+            "doi": "10.1101/2021.10.08.21264595"
+          },
+          "equations": []
+        },
+        "metadata": [],
+        "provenance": {
+          "method": "MIT annotation",
+          "description": "text, dataset, formula annotation (chunwei@mit.edu)"
         }
-      ]
-    }
+      }
+    ]
   }
+}

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -1,159 +1,292 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "description": {
+      "type": "string"
+    },
+    "model_version": {
+      "type": "string"
+    },
     "properties": {
-      "name": {"type": "string"},
-      "schema": {"type": "string", "format": "uri"},
-      "description": {"type": "string"},
-      "model_version": {"type": "string"},
-      "properties": {"type": "object"},
-      "model": {
-        "type": "object",
-        "properties": {
-          "states": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {"type": "string"},
-                "name": {"type": "string"},
-                "grounding": {"$ref": "#/$defs/grounding"},
-                "initial": {"$ref": "#/$defs/initial"}
+      "type": "object"
+    },
+    "model": {
+      "type": "object",
+      "properties": {
+        "states": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
               },
-              "required": ["id"]
-            }
-          },
-          "transitions": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {"type": "string"},
-                "input": {"type": "array", "items": {"type": "string"}},
-                "output": {"type": "array", "items": {"type": "string"}},
-                "grounding": {"$ref": "#/$defs/grounding"},
-                "properties": {"$ref": "#/$defs/properties"}
+              "name": {
+                "type": "string"
               },
-              "required": ["id", "input", "output"]
-            }
-          },
-          "parameters": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {"type": "string"},
-                "description": {"type": "string"},
-                "value": {"type": "number"},
-                "grounding": {"$ref": "#/$defs/grounding"},
-                "distribution": {"$ref": "#/$defs/distribution"}
+              "grounding": {
+                "$ref": "#/$defs/grounding"
               },
-              "required": ["id"]
-            }
+              "initial": {
+                "$ref": "#/$defs/initial"
+              }
+            },
+            "required": [
+              "id"
+            ]
           }
         },
-        "additionalProperties": false,
-        "required": ["states", "transitions", "parameters"]
-      },
-      "metadata": {
-        "type": "object",
-        "description": "(Optional) Information not useful for execution of the model, but that may be useful to some consumer in the future. E.g. creation timestamp or source paper's author."
-      }
-    },
-    "$defs": {
-      "initial": {
-        "type": "object",
-        "properties": {
-          "expression": {"type": "string"},
-          "expression_mathml": {"type": "string"}
-        },
-        "required": ["expression", "expression_mathml"],
-        "additionalProperties": true
-      },
-      "properties": {
-        "type": "object",
-        "properties": {
-          "name": {"type": "string"},
-          "grounding": {"$ref": "#/$defs/grounding"},
-          "rate": {"$ref": "#/$defs/rate"}
-        },
-        "required": ["name", "rate"],
-        "additionalProperties": true
-      },
-      "rate": {
-        "type": "object",
-        "properties": {
-          "expression": {"type": "string"},
-          "expression_mathml": {"type": "string"}
-        },
-        "required": ["expression", "expression_mathml"],
-        "additionalProperties": true
-      },
-      "distribution": {
-        "type": "object",
-        "properties": {
-          "type": {"type": "string"},
-          "parameters": {"type": "object"}
-        },
-        "required": ["type", "parameters"],
-        "additionalProperties": true
-      },
-      "grounding": {
-        "type": "object",
-        "properties": {
-          "identifiers": {"type": "object"},
-          "context": {"type": "object"}
-        },
-        "required": ["identifiers"],
-        "additionalProperties": false
-      },
-      "provenance": {
-        "type": "object",
-        "properties": {
-          "type": {"type": "string"},
-          "value": {"type": "string"}
-        },
-        "required": ["type", "value"],
-        "additionalProperties": false
-      },      
-      "metadatum": {
-        "type": "object",
-        "properties": {
-          "type": {"type": "string"},
-          "value": {"type": "string"}
-        },
-        "required": ["type", "value"],
-        "additionalProperties": false
-      },
-      "dataset": {
-        "type": "object",
-        "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "column": {"type": "string"},
-          "metadata": {"type": "object"}
-        },
-        "required": ["id"],
-        "additionalProperties": false
-      },
-      "paper": {
-        "type": "object",
-        "properties": {
-          "id": {"type": "string"},
-          "doi": {"type": "string"},          
-          "name": {"type": "string"},
-          "equations": {
-            "type": "array", 
-            "items": {
-              "type": "object"
+        "transitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "input": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "output": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "grounding": {
+                "$ref": "#/$defs/grounding"
+              },
+              "properties": {
+                "$ref": "#/$defs/properties"
               }
-          },
-          "metadata": {"type": "object"}
+            },
+            "required": [
+              "id",
+              "input",
+              "output"
+            ]
+          }
         },
-        "required": ["id", "doi"],
-        "additionalProperties": false
-      }         
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              },
+              "grounding": {
+                "$ref": "#/$defs/grounding"
+              },
+              "distribution": {
+                "$ref": "#/$defs/distribution"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "states",
+        "transitions",
+        "parameters"
+      ]
     },
-    "additionalProperties": true,
-    "required": ["name", "description", "schema", "model"]
-  }  
+    "metadata": {
+      "type": "object",
+      "description": "(Optional) Information not useful for execution of the model, but that may be useful to some consumer in the future. E.g. creation timestamp or source paper's author."
+    }
+  },
+  "$defs": {
+    "initial": {
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string"
+        },
+        "expression_mathml": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression",
+        "expression_mathml"
+      ],
+      "additionalProperties": true
+    },
+    "properties": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "grounding": {
+          "$ref": "#/$defs/grounding"
+        },
+        "rate": {
+          "$ref": "#/$defs/rate"
+        }
+      },
+      "required": [
+        "name",
+        "rate"
+      ],
+      "additionalProperties": true
+    },
+    "rate": {
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string"
+        },
+        "expression_mathml": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression",
+        "expression_mathml"
+      ],
+      "additionalProperties": true
+    },
+    "distribution": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "type",
+        "parameters"
+      ],
+      "additionalProperties": true
+    },
+    "grounding": {
+      "type": "object",
+      "properties": {
+        "identifiers": {
+          "type": "object"
+        },
+        "context": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "identifiers"
+      ],
+      "additionalProperties": false
+    },
+    "provenance": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "metadatum": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "dataset": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "column": {
+          "type": "string"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false
+    },
+    "paper": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "doi": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "equations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "doi"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "name",
+    "description",
+    "schema",
+    "model"
+  ]
+}

--- a/regnet/regnet_schema.json
+++ b/regnet/regnet_schema.json
@@ -2,11 +2,22 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "name": { "type": "string" },
-    "schema": { "type": "string", "format": "uri" },
-    "description": { "type": "string" },
-    "model_version": { "type": "string" },
-    "properties": { "type": "object" },
+    "name": {
+      "type": "string"
+    },
+    "schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "description": {
+      "type": "string"
+    },
+    "model_version": {
+      "type": "string"
+    },
+    "properties": {
+      "type": "object"
+    },
     "model": {
       "type": "object",
       "properties": {
@@ -14,26 +25,45 @@
           "type": "array",
           "items": {
             "allOf": [
-              { "$ref": "#/$defs/signed_graph_element" },
-              { "$ref": "#/$defs/base_properties" }
+              {
+                "$ref": "#/$defs/signed_graph_element"
+              },
+              {
+                "$ref": "#/$defs/base_properties"
+              }
             ],
             "type": "object",
             "properties": {
-              "initial": { "$ref": "#/$defs/param_or_number" }
+              "initial": {
+                "$ref": "#/$defs/param_or_number"
+              }
             }
           }
         },
         "edges": {
           "type": "array",
           "items": {
-            "allOf": [ { "$ref": "#/$defs/signed_graph_element" } ],
+            "allOf": [
+              {
+                "$ref": "#/$defs/signed_graph_element"
+              }
+            ],
             "type": "object",
             "properties": {
-              "source": { "type": "string" },
-              "target": { "type": "string" },
-              "properties": { "$ref": "#/$defs/base_properties" }
+              "source": {
+                "type": "string"
+              },
+              "target": {
+                "type": "string"
+              },
+              "properties": {
+                "$ref": "#/$defs/base_properties"
+              }
             },
-            "required": ["source", "target"]
+            "required": [
+              "source",
+              "target"
+            ]
           }
         },
         "parameters": {
@@ -41,18 +71,33 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": { "type": "string" },
-              "description": { "type": "string" },
-              "value": { "type": "number" },
-              "grounding": { "$ref": "#/$defs/grounding" },
-              "distribution": { "$ref": "#/$defs/distribution" }
+              "id": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "value": {
+                "type": "number"
+              },
+              "grounding": {
+                "$ref": "#/$defs/grounding"
+              },
+              "distribution": {
+                "$ref": "#/$defs/distribution"
+              }
             },
-            "required": ["id"]
+            "required": [
+              "id"
+            ]
           }
         }
       },
       "additionalProperties": false,
-      "required": ["vertices", "edges"]
+      "required": [
+        "vertices",
+        "edges"
+      ]
     },
     "metadata": {
       "type": "object",
@@ -62,42 +107,75 @@
   "$defs": {
     "param_or_number": {
       "anyOf": [
-        { "type": "number" },
-        { "type": "string" }
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
       ]
     },
     "signed_graph_element": {
       "type": "object",
       "properties": {
-        "id": { "type": "string" },
-        "sign": { "type": "boolean" }
+        "id": {
+          "type": "string"
+        },
+        "sign": {
+          "type": "boolean"
+        }
       },
-      "required": ["id", "sign"]
+      "required": [
+        "id",
+        "sign"
+      ]
     },
     "base_properties": {
       "type": "object",
       "properties": {
-        "name": { "type": "string" },
-        "grounding": { "$ref": "#/$defs/grounding" },
-        "rate_constant": { "$ref": "#/$defs/param_or_number" }
+        "name": {
+          "type": "string"
+        },
+        "grounding": {
+          "$ref": "#/$defs/grounding"
+        },
+        "rate_constant": {
+          "$ref": "#/$defs/param_or_number"
+        }
       }
     },
     "distribution": {
       "type": "object",
       "properties": {
-        "type": { "type": "string" },
-        "parameters": { "type": "object" }
+        "type": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "object"
+        }
       },
-      "required": ["type", "parameters"]
+      "required": [
+        "type",
+        "parameters"
+      ]
     },
     "grounding": {
       "type": "object",
       "properties": {
-        "identifiers": { "type": "object" },
-        "context": { "type": "object" }
+        "identifiers": {
+          "type": "object"
+        },
+        "context": {
+          "type": "object"
+        }
       },
       "additionalProperties": false
     }
   },
-  "required": ["name", "description", "schema", "model"]
+  "required": [
+    "name",
+    "description",
+    "schema",
+    "model"
+  ]
 }


### PR DESCRIPTION
This PR standardizes the formatting of all JSON files with 2-space indentation. This can be reproduced with the standard `jq` command line tool, for instance. Fixes #23.