### PR TITLE
Add typing for stratification etc. as a "semantic"

### DIFF
--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -85,12 +85,12 @@
             {
                 "id": "Infect",
                 "input": [
-                "Pop",
-                "Pop"
+                    "Pop",
+                    "Pop"
                 ],
                 "output": [
-                "Pop",
-                "Pop"
+                    "Pop",
+                    "Pop"
                 ],
                 "properties": {
                     "name": "Infect",
@@ -100,10 +100,10 @@
             {
                 "id": "Disease",
                 "input": [
-                "Pop"
+                    "Pop"
                 ],
                 "output": [
-                "Pop"
+                    "Pop"
                 ],
                 "properties": {
                     "name": "Disease",
@@ -113,10 +113,10 @@
             {
                 "id": "Strata",
                 "input": [
-                "Pop"
+                    "Pop"
                 ],
                 "output": [
-                "Pop"
+                    "Pop"
                 ],
                 "properties": {
                     "name": "Strata",
@@ -126,11 +126,11 @@
             {
                 "id": "Vaccinate",
                 "input": [
-                "Pop",
-                "Vaccine"
+                    "Pop",
+                    "Vaccine"
                 ],
                 "output": [
-                "Pop"
+                    "Pop"
                 ],
                 "properties": {
                     "name": "Vaccinate",
@@ -141,7 +141,7 @@
                 "id": "Produce_Vaccine",
                 "input": [],
                 "output": [
-                "Vaccine"
+                    "Vaccine"
                 ],
                 "properties": {
                     "name": "Produce Vaccine",

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -67,155 +67,6 @@
             }
         ]
     },
-    "type_system": {
-        "states": [
-            {
-                "id": "Pop",
-                "name": "Pop",
-                "description": "Compartment of individuals in a human population"
-            },
-            {
-                "id": "Vaccine",
-                "name": "Vaccine",
-                "description": "Compartment of vaccine doses available for use in a vaccination campaign"
-            }
-        ],
-        "transitions": [
-            {
-                "id": "Infect",
-                "input": [
-                    "Pop",
-                    "Pop"
-                ],
-                "output": [
-                    "Pop",
-                    "Pop"
-                ],
-                "properties": {
-                    "name": "Infect",
-                    "description": "2-to-2 interaction that represents infectious contact between two human individuals"
-                }
-            },
-            {
-                "id": "Disease",
-                "input": [
-                    "Pop"
-                ],
-                "output": [
-                    "Pop"
-                ],
-                "properties": {
-                    "name": "Disease",
-                    "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
-                }
-            },
-            {
-                "id": "Strata",
-                "input": [
-                    "Pop"
-                ],
-                "output": [
-                    "Pop"
-                ],
-                "properties": {
-                    "name": "Strata",
-                    "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
-                }
-            },
-            {
-                "id": "Vaccinate",
-                "input": [
-                    "Pop",
-                    "Vaccine"
-                ],
-                "output": [
-                    "Pop"
-                ],
-                "properties": {
-                    "name": "Vaccinate",
-                    "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
-                }
-            },
-            {
-                "id": "Produce_Vaccine",
-                "input": [],
-                "output": [
-                    "Vaccine"
-                ],
-                "properties": {
-                    "name": "Produce Vaccine",
-                    "description": "0-to-1 interaction that represents the production of a single vaccine dose."
-                }
-            }
-        ]
-      },
-      "typing": {
-        "states": [
-            {
-                "id": "S"
-            },
-            {
-                "id": "I"
-            },
-            {
-                "id": "R"
-            },
-            {
-                "id": "inf"
-            },
-            {
-                "id": "rec"
-            },
-            {
-                "id": "Pop"
-            },
-            {
-                "id": "Vaccine"
-            },
-            {
-                "id": "Infect"
-            },
-            {
-                "id": "Disease"
-            },
-            {
-                "id": "Strata"
-            },
-            {
-                "id": "Vaccinate"
-            },
-            {
-                "id": "Produce_Vaccine"
-            }
-        ],
-        "transition": [
-            {
-                "id": "0",
-                "input": ["S"],
-                "output": ["Pop"]
-            },
-            {
-                "id": "1",
-                "input": ["I"],
-                "output": ["Pop"]
-            },
-            {
-                "id": "2",
-                "input": ["R"],
-                "output": ["Pop"]
-            },
-            {
-                "id": "3",
-                "input": ["inf"],
-                "output": ["Infect"]
-            },
-            {
-                "id": "4",
-                "input": ["rec"],
-                "output": ["Disease"]
-            }
-        ]
-      },
     "semantics": {
       "ode": {
         "rates": [
@@ -292,6 +143,97 @@
             "description": "Total recovered population at timestep 0",
             "value": 0
           }
+        ]
+      },
+      "typing": {
+        "type_system": {
+          "states": [
+            {
+                "id": "Pop",
+                "name": "Pop",
+                "description": "Compartment of individuals in a human population"
+            },
+            {
+                "id": "Vaccine",
+                "name": "Vaccine",
+                "description": "Compartment of vaccine doses available for use in a vaccination campaign"
+            }
+          ],
+          "transitions": [
+            {
+                "id": "Infect",
+                "input": [
+                    "Pop",
+                    "Pop"
+                ],
+                "output": [
+                    "Pop",
+                    "Pop"
+                ],
+                "properties": {
+                    "name": "Infect",
+                    "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+                }
+            },
+            {
+                "id": "Disease",
+                "input": [
+                    "Pop"
+                ],
+                "output": [
+                    "Pop"
+                ],
+                "properties": {
+                    "name": "Disease",
+                    "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+                }
+            },
+            {
+                "id": "Strata",
+                "input": [
+                    "Pop"
+                ],
+                "output": [
+                    "Pop"
+                ],
+                "properties": {
+                    "name": "Strata",
+                    "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+                }
+            },
+            {
+                "id": "Vaccinate",
+                "input": [
+                    "Pop",
+                    "Vaccine"
+                ],
+                "output": [
+                    "Pop"
+                ],
+                "properties": {
+                    "name": "Vaccinate",
+                    "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+                }
+            },
+            {
+                "id": "Produce_Vaccine",
+                "input": [],
+                "output": [
+                    "Vaccine"
+                ],
+                "properties": {
+                    "name": "Produce Vaccine",
+                    "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+                }
+            }
+          ]
+        },
+        "type_map": [
+          ["S", "Pop"],
+          ["I", "Pop"],
+          ["R", "Pop"],
+          ["inf", "Infect"],
+          ["rec", "Disease"]
         ]
       }
     },

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -1,0 +1,355 @@
+{
+    "name": "SIR Model",
+    "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
+    "description": "Typed SIR model created by Nelson, derived from the one by Ben, Micah, Brandon",
+    "model_version": "0.1",
+    "model": {
+        "states": [
+            {
+                "id": "S",
+                "name": "Susceptible",
+                "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
+                "grounding": {
+                    "identifiers": {
+                    "ido": "0000514"
+                    }
+                }
+            },
+            {
+                "id": "I",
+                "name": "Infected",
+                "description": "Number of individuals relative to the total population that are 'infected' by a disease",
+                "grounding": {
+                    "identifiers": {
+                    "ido": "0000511"
+                    }
+                }
+            },
+            {
+                "id": "R",
+                "name": "Recovered",
+                "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
+                "grounding": {
+                    "identifiers": {
+                    "ido": "0000592"
+                    }
+                }
+            }
+        ],
+        "transitions": [
+            {
+                "id": "inf",
+                "input": [
+                    "S",
+                    "I"
+                ],
+                "output": [
+                    "I",
+                    "I"
+                ],
+                "properties": {
+                    "name": "Infection",
+                    "description": "Infective interaction between individuals"
+                }
+            },
+            {
+                "id": "rec",
+                "input": [
+                    "I"
+                ],
+                "output": [
+                    "R"
+                ],
+                "properties": {
+                    "name": "Recovery",
+                    "description": "Recovery interaction of a infected individual"
+                }
+            }
+        ]
+    },
+    "type_system": {
+        "states": [
+            {
+                "id": "Pop",
+                "name": "Pop",
+                "description": "Compartment of individuals in a human population",
+
+            },
+            {
+                "id": "Vaccine",
+                "name": "Vaccine",
+                "description": "Compartment of vaccine doses available for use in a vaccination campaign",
+            }
+        ],
+        "transitions": [
+            {
+                "id": "Infect",
+                "input": [
+                "Pop",
+                "Pop"
+                ],
+                "output": [
+                "Pop",
+                "Pop"
+                ],
+                "properties": {
+                    "name": "Infect",
+                    "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+                }
+            },
+            {
+                "id": "Disease",
+                "input": [
+                "Pop"
+                ],
+                "output": [
+                "Pop"
+                ],
+                "properties": {
+                    "name": "Disease",
+                    "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+                }
+            },
+            {
+                "id": "Strata",
+                "input": [
+                "Pop"
+                ],
+                "output": [
+                "Pop"
+                ],
+                "properties": {
+                    "name": "Strata",
+                    "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+                }
+            },
+            {
+                "id": "Vaccinate",
+                "input": [
+                "Pop",
+                "Vaccine"
+                ],
+                "output": [
+                "Pop"
+                ],
+                "properties": {
+                    "name": "Vaccinate",
+                    "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+                }
+            },
+            {
+                "id": "Produce_Vaccine",
+                "input": [],
+                "output": [
+                "Vaccine"
+                ],
+                "properties": {
+                    "name": "Produce Vaccine",
+                    "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+                }
+            }
+        ]
+      },
+      "typing": {
+        "states": [
+            {
+                "id": "S"
+            },
+            {
+                "id": "I"
+            },
+            {
+                "id": "R"
+            },
+            {
+                "id": "inf"
+            },
+            {
+                "id": "rec"
+            },
+            {
+                "id": "Pop"
+            },
+            {
+                "id": "Vaccine"
+            },
+            {
+                "id": "Infect",
+            },
+            {
+                "id": "Disease",
+            },
+            {
+                "id": "Strata"
+            },
+            {
+                "id": "Vaccinate"
+            },
+            {
+                "id": "Produce_Vaccine"
+            }
+        ],
+        "transition": [
+            {
+                "id": "0",
+                "input": ["S"],
+                "output": ["Pop"]
+            },
+            {
+                "id": "1",
+                "input": ["I"],
+                "output": ["Pop"]
+            },
+            {
+                "id": "2",
+                "input": ["R"],
+                "output": ["Pop"]
+            },
+            {
+                "id": "3",
+                "input": ["inf"],
+                "output": ["Infect"]
+            },
+            {
+                "id": "4",
+                "input": ["rec"],
+                "output": ["Disease"]
+            }
+        ]
+      }
+    "semantics": {
+      "ode": {
+        "rates": [
+          {
+            "target": "inf",
+            "expression": "S*I*beta",
+            "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
+          },
+          {
+            "target": "rec",
+            "expression": "I*gamma",
+            "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
+          }
+        ],
+        "initials": [
+          {
+            "target": "S",
+            "expression": "S0",
+            "expression_mathml": "<ci>S0</ci>"
+          },
+          {
+            "target": "I",
+            "expression": "I0",
+            "expression_mathml": "<ci>I0</ci>"
+          },
+          {
+            "target": "R",
+            "expression": "R0",
+            "expression_mathml": "<ci>R0</ci>"
+          }
+        ],
+        "parameters": [
+          {
+            "id": "beta",
+            "description": "infection rate",
+            "value": 0.027,
+            "distribution": {
+              "type": "StandardUniform1",
+              "parameters": {
+                "minimum": 0.026,
+                "maximum": 0.028
+              }
+            }
+          },
+          {
+            "id": "gamma",
+            "description": "recovery rate",
+            "grounding": {
+              "identifiers": {
+                "askemo": "0000013"
+              }
+            },
+            "value": 0.14,
+            "distribution": {
+              "type": "StandardUniform1",
+              "parameters": {
+                "minimum": 0.1,
+                "maximum": 0.18
+              }
+            }
+          },
+          {
+            "id": "S0",
+            "description": "Total susceptible population at timestep 0",
+            "value": 1000
+          },
+          {
+            "id": "I0",
+            "description": "Total infected population at timestep 0",
+            "value": 1
+          },
+          {
+            "id": "R0",
+            "description": "Total recovered population at timestep 0",
+            "value": 0
+          }
+        ]
+      }
+    },
+    "metadata": {
+      "processed_at": 1682964953,
+      "processed_by": "mit:process-node1",
+      "variable_statements": [
+        {
+          "id": "v0",
+          "variable": {
+            "id": "v0",
+            "name": "VE",
+            "metadata": [
+              {
+                "type": "text_annotation",
+                "value": " Vaccine Effectiveness"
+              },
+              {
+                "type": "text_annotation",
+                "value": " Vaccine Effectiveness"
+              }
+            ],
+            "dkg_groundings": [],
+            "column": [
+              {
+                "id": "9-2",
+                "name": "new_persons_vaccinated",
+                "dataset": {
+                  "id": "9",
+                  "name": "usa-vaccinations.csv",
+                  "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+                }
+              },
+              {
+                "id": "9-3",
+                "name": "cumulative_persons_vaccinated",
+                "dataset": {
+                  "id": "9",
+                  "name": "usa-vaccinations.csv",
+                  "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+                }
+              }
+            ],
+            "paper": {
+              "id": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
+              "file_directory": "https://www.medrxiv.org/content/10.1101/2021.10.08.21264595v1",
+              "doi": "10.1101/2021.10.08.21264595"
+            },
+            "equations": []
+          },
+          "metadata": [],
+          "provenance": {
+            "method": "MIT annotation",
+            "description": "text, dataset, formula annotation (chunwei@mit.edu)"
+          }
+        }
+      ]
+    }
+  }
+  

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -72,13 +72,12 @@
             {
                 "id": "Pop",
                 "name": "Pop",
-                "description": "Compartment of individuals in a human population",
-
+                "description": "Compartment of individuals in a human population"
             },
             {
                 "id": "Vaccine",
                 "name": "Vaccine",
-                "description": "Compartment of vaccine doses available for use in a vaccination campaign",
+                "description": "Compartment of vaccine doses available for use in a vaccination campaign"
             }
         ],
         "transitions": [

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -173,10 +173,10 @@
                 "id": "Vaccine"
             },
             {
-                "id": "Infect",
+                "id": "Infect"
             },
             {
-                "id": "Disease",
+                "id": "Disease"
             },
             {
                 "id": "Strata"
@@ -215,7 +215,7 @@
                 "output": ["Disease"]
             }
         ]
-      }
+      },
     "semantics": {
       "ode": {
         "rates": [

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -82,6 +82,136 @@
         "transitions"
       ]
     },
+    "type_system": {
+      "type": "object",
+      "description": "(Optional) A Petri net representing the 'type system' that is necessary to align states and transitions across different models during stratification.",
+      "properties": {
+        "states": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "grounding": {
+                "$ref": "#/$defs/grounding"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          }
+        },
+        "transitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "input": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "output": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "grounding": {
+                "$ref": "#/$defs/grounding"
+              },
+              "properties": {
+                "$ref": "#/$defs/properties"
+              }
+            },
+            "required": [
+              "id",
+              "input",
+              "output"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "states",
+        "transitions"
+      ]
+    },
+    "typing": {
+      "type": "object",
+      "description": "(Optional) A Petri net representing the assignment of model nodes to their corresponding node in the type system.",
+      "properties": {
+        "states": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "grounding": {
+                "$ref": "#/$defs/grounding"
+              }
+            },
+            "required": [
+              "id"
+            ]
+          }
+        },
+        "transitions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "input": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "output": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "grounding": {
+                "$ref": "#/$defs/grounding"
+              },
+              "properties": {
+                "$ref": "#/$defs/properties"
+              }
+            },
+            "required": [
+              "id",
+              "input",
+              "output"
+            ]
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "states",
+        "transitions"
+      ]
+    },
     "semantics": {
       "type": "object",
       "description": "Information specific to a given semantics (e.g., ODEs) associated with a model.",

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -22,188 +22,10 @@
       "type": "object",
       "properties": {
         "states": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "grounding": {
-                "$ref": "#/$defs/grounding"
-              }
-            },
-            "required": [
-              "id"
-            ]
-          }
+          "$ref": "#/$defs/states"
         },
         "transitions": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "input": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "output": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "grounding": {
-                "$ref": "#/$defs/grounding"
-              },
-              "properties": {
-                "$ref": "#/$defs/properties"
-              }
-            },
-            "required": [
-              "id",
-              "input",
-              "output"
-            ]
-          }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "states",
-        "transitions"
-      ]
-    },
-    "type_system": {
-      "type": "object",
-      "description": "(Optional) A Petri net representing the 'type system' that is necessary to align states and transitions across different models during stratification.",
-      "properties": {
-        "states": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "grounding": {
-                "$ref": "#/$defs/grounding"
-              }
-            },
-            "required": [
-              "id"
-            ]
-          }
-        },
-        "transitions": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "input": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "output": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "grounding": {
-                "$ref": "#/$defs/grounding"
-              },
-              "properties": {
-                "$ref": "#/$defs/properties"
-              }
-            },
-            "required": [
-              "id",
-              "input",
-              "output"
-            ]
-          }
-        }
-      },
-      "additionalProperties": false,
-      "required": [
-        "states",
-        "transitions"
-      ]
-    },
-    "typing": {
-      "type": "object",
-      "description": "(Optional) A Petri net representing the assignment of model nodes to their corresponding node in the type system.",
-      "properties": {
-        "states": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "grounding": {
-                "$ref": "#/$defs/grounding"
-              }
-            },
-            "required": [
-              "id"
-            ]
-          }
-        },
-        "transitions": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "input": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "output": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              },
-              "grounding": {
-                "$ref": "#/$defs/grounding"
-              },
-              "properties": {
-                "$ref": "#/$defs/properties"
-              }
-            },
-            "required": [
-              "id",
-              "input",
-              "output"
-            ]
-          }
+          "$ref": "#/$defs/transitions"
         }
       },
       "additionalProperties": false,
@@ -218,6 +40,10 @@
       "properties": {
         "ode": {
           "$ref": "#/$defs/odeSemantics"
+        },
+        "typing": {
+          "description": "(Optional) Information for aligning models for stratification",
+          "$ref": "#/$defs/typingSemantics"
         }
       }
     },
@@ -227,6 +53,63 @@
     }
   },
   "$defs": {
+    "states": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "grounding": {
+            "$ref": "#/$defs/grounding"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }      
+    },
+    "transitions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "input": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "output": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "grounding": {
+            "$ref": "#/$defs/grounding"
+          },
+          "properties": {
+            "$ref": "#/$defs/properties"
+          }
+        },
+        "required": [
+          "id",
+          "input",
+          "output"
+        ]
+      }
+    },
     "properties": {
       "type": "object",
       "properties": {
@@ -353,6 +236,41 @@
         "doi"
       ],
       "additionalProperties": false
+    },
+    "typingSemantics": {
+      "type": "object",
+      "properties": {
+        "type_system": {
+          "type": "object",
+          "description": "A Petri net representing the 'type system' that is necessary to align states and transitions across different models during stratification.",
+          "properties": {
+            "states": {
+              "$ref": "#/$defs/states"
+            },
+            "transitions": {
+              "$ref": "#/$defs/transitions"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "states",
+            "transitions"
+          ]
+        },
+        "type_map": {
+          "type": "object",
+          "description": "A map between the (state and transition) nodes of the model and the (state and transition) nodes of the type system",
+          "properties": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     },
     "odeSemantics": {
       "type": "object",

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -258,15 +258,12 @@
           ]
         },
         "type_map": {
-          "type": "object",
+          "type": "array",
           "description": "A map between the (state and transition) nodes of the model and the (state and transition) nodes of the type system",
-          "properties": {
+          "items": {
             "type": "array",
             "items": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+              "type": "string"
             }
           }
         }


### PR DESCRIPTION
A more complicated implementation of typing (in the context of model stratification):
* Alongside `model`, add two other Petri nets called `type_system` and `typing`
* `type_system` represents the higher-level, cross-model "types" of state nodes and transition nodes (akin to function signatures), e.g. `Pop` -(2)-> `Infect` -(2)-> `Pop`
* `typing` represents the mapping between the model nodes and the type-system nodes, e.g. `S` -> `Pop` and `inf` -> `Infect`