### PR TITLE
Set schema as an object

### DIFF
--- a/base_schema.json
+++ b/base_schema.json
@@ -11,9 +11,24 @@
       "description": "A description of the model."
     },
     "schema": {
-      "type": "string",
-      "format": "uri",
-      "description": "URI of a JSON schema document that describes the model stored in the 'model' parameter."
+      "type": "object",
+      "description": "Object that describes the model stored in the 'model' parameter, including its schema, framework, and version.",
+      "properties": {
+          "schema_uri": {
+              "type": "string",
+              "format": "uri",
+              "description": "URI of a JSON schema document."
+          },
+          "framework": {
+              "type": "string",
+              "description": "Name of the framework."
+          },
+          "version": {
+              "type": "string",
+              "description": "Framework version."
+          }
+      },
+      "required": ["schema_uri", "framework", "version"]
     },
     "model": {
       "type": "object",

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -1,6 +1,10 @@
 {
   "name": "SIR Model",
-  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
+  "schema": {
+    "schema_uri": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
+    "framework": "Petri Net",
+    "version": "0.1"
+  },
   "description": "SIR model created by Ben, Micah, Brandon",
   "model_version": "0.1",
   "model": {

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -6,8 +6,13 @@
       "type": "string"
     },
     "schema": {
-      "type": "string",
-      "format": "uri"
+      "type": "object",
+      "properties": {
+        "schema_uri": {"type": "string", "format": "uri"},
+        "framework": {"type": "string"},
+        "version": {"type": "string"}
+      },
+      "required": ["schema_uri", "framework", "version"]
     },
     "description": {
       "type": "string"

--- a/regnet/examples/lotka_volterra.json
+++ b/regnet/examples/lotka_volterra.json
@@ -1,6 +1,10 @@
 {
   "name": "Lotka Volterra",
-  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.1/regnet/regnet_schema.json",
+  "schema": {
+    "schema_uri": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.1/regnet/regnet_schema.json",
+    "framework": "Regulatory Network",
+    "version": "0.1"
+  },
   "description": "Lotka Volterra model",
   "model_version": "0.1",
   "model": {

--- a/regnet/examples/syntax_edge_cases.json
+++ b/regnet/examples/syntax_edge_cases.json
@@ -1,6 +1,10 @@
 {
   "name": "Syntax Edge Cases",
-  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.1/regnet/regnet_schema.json",
+  "schema": {
+    "schema_uri": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.1/regnet/regnet_schema.json",
+    "framework": "Regulatory Network",
+    "version": "0.1"
+  },
   "description": "A regulatory network to demonstrate syntactic edge cases of the JSON Schema of RegNets.",
   "model_version": "0.1",
   "model": {

--- a/regnet/regnet_schema.json
+++ b/regnet/regnet_schema.json
@@ -6,8 +6,13 @@
       "type": "string"
     },
     "schema": {
-      "type": "string",
-      "format": "uri"
+      "type": "object",
+      "properties": {
+        "schema_uri": {"type": "string", "format": "uri"},
+        "framework": {"type": "string"},
+        "version": {"type": "string"}
+      },
+      "required": ["schema_uri", "framework", "version"]
     },
     "description": {
       "type": "string"


### PR DESCRIPTION
## What's New
This PR proposes changing `schema` from a simple URI to the relevant schema file into a more complex object that will include:

* `schema_uri`
* `framework`: the name of the framework, e.g. `Petri net`
* `version`: the version of the schema

This benefits TA4 substantially since it means the HMI will not be required to store mappings between the `schema_uri` and the framework name or version. It will facilitate "search by framework (representation)" in the HMI out of the box.

## Impact on TAs 1-3
I do not foresee major impact to any other TAs except the extent to which the `schema_uri` is needed for processing; this will have to be accessed 1 level deeper than currently. 

This does imply a small update to TA1 model reconstruction from equations capabilities since the reconstructed model will have to conform to this new spec.