### PR TITLE
Add observables for Petri nets

### DIFF
--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -60,13 +60,6 @@
           "name": "Recovery"
         }
       }
-    ],
-    "observables": [
-      {
-        "id": "noninf",
-        "name": "Non-infectious",
-        "states": ["S", "R"]
-      }
     ]
   },
   "semantics": {
@@ -148,7 +141,9 @@
       ],
       "observables": [
         {
-          "target": "noninf",
+          "id": "noninf",
+          "name": "Non-infectious",
+          "states": ["S", "R"],
           "expression": "S+R",
           "expression_mathml": "<apply><plus/><ci>S</ci><ci>R</ci></apply>"
         }

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -60,6 +60,13 @@
           "name": "Recovery"
         }
       }
+    ],
+    "observables": [
+      {
+        "id": "noninf",
+        "name": "Non-infectious",
+        "states": ["S", "R"]
+      }
     ]
   },
   "semantics": {
@@ -137,6 +144,13 @@
           "id": "R0",
           "description": "Total recovered population at timestep 0",
           "value": 0
+        }
+      ],
+      "observables": [
+        {
+          "target": "noninf",
+          "expression": "S+R",
+          "expression_mathml": "<apply><plus/><ci>S</ci><ci>R</ci></apply>"
         }
       ]
     }

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -26,6 +26,9 @@
         },
         "transitions": {
           "$ref": "#/$defs/transitions"
+        },
+        "observables": {
+          "$ref": "#/$defs/observables"
         }
       },
       "additionalProperties": false,
@@ -107,6 +110,35 @@
           "id",
           "input",
           "output"
+        ]
+      }
+    },
+    "observables": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "grounding": {
+            "$ref": "#/$defs/grounding"
+          },
+          "states": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id"
         ]
       }
     },
@@ -330,6 +362,23 @@
             "required": [
               "id"
             ]
+          }
+        },
+        "observables": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "string"
+              },
+              "expression": {
+                "type": "string"
+              },
+              "expression_mathml": {
+                "type": "string"
+              }
+            }
           }
         }
       }

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -26,9 +26,6 @@
         },
         "transitions": {
           "$ref": "#/$defs/transitions"
-        },
-        "observables": {
-          "$ref": "#/$defs/observables"
         }
       },
       "additionalProperties": false,
@@ -135,6 +132,12 @@
             "items": {
               "type": "string"
             }
+          },
+          "expression": {
+            "type": "string"
+          },
+          "expression_mathml": {
+            "type": "string"
           }
         },
         "required": [
@@ -362,23 +365,6 @@
             "required": [
               "id"
             ]
-          }
-        },
-        "observables": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "target": {
-                "type": "string"
-              },
-              "expression": {
-                "type": "string"
-              },
-              "expression_mathml": {
-                "type": "string"
-              }
-            }
           }
         }
       }


### PR DESCRIPTION
This PR extends the Petri net schema to be able to represent observables. The implementation follows discussions at last Friday's meeting as follows:
- Added a section for `observables` within the `model` which provides an ID for the observable and simply refers to the `states` that are involved in the observable.
- Added a section for `observables` under ODE semantics where the actual expression for the observable is defined. The structure here is the same as for rate laws, except these refer to observable IDs rather than transition IDs.
- Updated the SIR model with an example observable.