### PR TITLE
34 missing the id name description properties

### DIFF
--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -8,6 +8,7 @@
       {
         "id": "S",
         "name": "Susceptible",
+        "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
         "grounding": {
           "identifiers": {
             "ido": "0000514"
@@ -17,6 +18,7 @@
       {
         "id": "I",
         "name": "Infected",
+        "description": "Number of individuals relative to the total population that are 'infected' by a disease",
         "grounding": {
           "identifiers": {
             "ido": "0000511"
@@ -26,6 +28,7 @@
       {
         "id": "R",
         "name": "Recovered",
+        "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
         "grounding": {
           "identifiers": {
             "ido": "0000592"
@@ -45,7 +48,8 @@
           "I"
         ],
         "properties": {
-          "name": "Infection"
+          "name": "Infection",
+          "description": "Infective interaction between individuals"
         }
       },
       {
@@ -57,7 +61,8 @@
           "R"
         ],
         "properties": {
-          "name": "Recovery"
+          "name": "Recovery",
+          "description": "Recovery interaction of a infected individual"
         }
       }
     ]
@@ -96,6 +101,7 @@
       "parameters": [
         {
           "id": "beta",
+          "name": "β",
           "description": "infection rate",
           "value": 0.027,
           "distribution": {
@@ -108,6 +114,7 @@
         },
         {
           "id": "gamma",
+          "name": "γ",
           "description": "recovery rate",
           "grounding": {
             "identifiers": {
@@ -125,16 +132,19 @@
         },
         {
           "id": "S0",
+          "name": "S₀",
           "description": "Total susceptible population at timestep 0",
           "value": 1000
         },
         {
           "id": "I0",
+          "name": "I₀",
           "description": "Total infected population at timestep 0",
           "value": 1
         },
         {
           "id": "R0",
+          "name": "R₀",
           "description": "Total recovered population at timestep 0",
           "value": 0
         }

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -8,7 +8,7 @@
       {
         "id": "S",
         "name": "Susceptible",
-        "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
+        "description": "Number of individuals that are 'susceptible' to a disease infection",
         "grounding": {
           "identifiers": {
             "ido": "0000514"
@@ -18,7 +18,7 @@
       {
         "id": "I",
         "name": "Infected",
-        "description": "Number of individuals relative to the total population that are 'infected' by a disease",
+        "description": "Number of individuals that are 'infected' by a disease",
         "grounding": {
           "identifiers": {
             "ido": "0000511"
@@ -28,7 +28,7 @@
       {
         "id": "R",
         "name": "Recovered",
-        "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
+        "description": "Number of individuals that have 'recovered' from a disease infection",
         "grounding": {
           "identifiers": {
             "ido": "0000592"
@@ -49,7 +49,7 @@
         ],
         "properties": {
           "name": "Infection",
-          "description": "Infective interaction between individuals"
+          "description": "Infective process between individuals"
         }
       },
       {
@@ -62,7 +62,7 @@
         ],
         "properties": {
           "name": "Recovery",
-          "description": "Recovery interaction of a infected individual"
+          "description": "Recovery process of a infected individual"
         }
       }
     ]

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -1,301 +1,301 @@
 {
-    "name": "SIR Model",
-    "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
-    "description": "Typed SIR model created by Nelson, derived from the one by Ben, Micah, Brandon",
-    "model_version": "0.1",
-    "model": {
-        "states": [
-            {
-                "id": "S",
-                "name": "Susceptible",
-                "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
-                "grounding": {
-                  "identifiers": {
-                    "ido": "0000514"
-                  }
-                }
-            },
-            {
-                "id": "I",
-                "name": "Infected",
-                "description": "Number of individuals relative to the total population that are 'infected' by a disease",
-                "grounding": {
-                  "identifiers": {
-                    "ido": "0000511"
-                  }
-                }
-            },
-            {
-                "id": "R",
-                "name": "Recovered",
-                "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
-                "grounding": {
-                  "identifiers": {
-                    "ido": "0000592"
-                  }
-                }
+  "name": "SIR Model",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
+  "description": "Typed SIR model created by Nelson, derived from the one by Ben, Micah, Brandon",
+  "model_version": "0.1",
+  "model": {
+    "states": [
+      {
+        "id": "S",
+        "name": "Susceptible",
+        "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000514"
+          }
+        }
+      },
+      {
+        "id": "I",
+        "name": "Infected",
+        "description": "Number of individuals relative to the total population that are 'infected' by a disease",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000511"
+          }
+        }
+      },
+      {
+        "id": "R",
+        "name": "Recovered",
+        "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000592"
+          }
+        }
+      }
+    ],
+    "transitions": [
+      {
+        "id": "inf",
+        "input": [
+          "S",
+          "I"
+        ],
+        "output": [
+          "I",
+          "I"
+        ],
+        "properties": {
+          "name": "Infection",
+          "description": "Infective interaction between individuals"
+        }
+      },
+      {
+        "id": "rec",
+        "input": [
+          "I"
+        ],
+        "output": [
+          "R"
+        ],
+        "properties": {
+          "name": "Recovery",
+          "description": "Recovery interaction of a infected individual"
+        }
+      }
+    ]
+  },
+  "semantics": {
+    "ode": {
+      "rates": [
+        {
+          "target": "inf",
+          "expression": "S*I*beta",
+          "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
+        },
+        {
+          "target": "rec",
+          "expression": "I*gamma",
+          "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
+        }
+      ],
+      "initials": [
+        {
+          "target": "S",
+          "expression": "S0",
+          "expression_mathml": "<ci>S0</ci>"
+        },
+        {
+          "target": "I",
+          "expression": "I0",
+          "expression_mathml": "<ci>I0</ci>"
+        },
+        {
+          "target": "R",
+          "expression": "R0",
+          "expression_mathml": "<ci>R0</ci>"
+        }
+      ],
+      "parameters": [
+        {
+          "id": "beta",
+          "name": "β",
+          "description": "infection rate",
+          "value": 0.027,
+          "distribution": {
+            "type": "StandardUniform1",
+            "parameters": {
+              "minimum": 0.026,
+              "maximum": 0.028
             }
+          }
+        },
+        {
+          "id": "gamma",
+          "name": "γ",
+          "description": "recovery rate",
+          "grounding": {
+            "identifiers": {
+              "askemo": "0000013"
+            }
+          },
+          "value": 0.14,
+          "distribution": {
+            "type": "StandardUniform1",
+            "parameters": {
+              "minimum": 0.1,
+              "maximum": 0.18
+            }
+          }
+        },
+        {
+          "id": "S0",
+          "name": "S₀",
+          "description": "Total susceptible population at timestep 0",
+          "value": 1000
+        },
+        {
+          "id": "I0",
+          "name": "I₀",
+          "description": "Total infected population at timestep 0",
+          "value": 1
+        },
+        {
+          "id": "R0",
+          "name": "R₀",
+          "description": "Total recovered population at timestep 0",
+          "value": 0
+        }
+      ]
+    },
+    "typing": {
+      "type_system": {
+        "states": [
+          {
+              "id": "Pop",
+              "name": "Pop",
+              "description": "Compartment of individuals in a human population"
+          },
+          {
+              "id": "Vaccine",
+              "name": "Vaccine",
+              "description": "Compartment of vaccine doses available for use in a vaccination campaign"
+          }
         ],
         "transitions": [
-            {
-              "id": "inf",
+          {
+              "id": "Infect",
               "input": [
-                "S",
-                "I"
+                "Pop",
+                "Pop"
               ],
               "output": [
-                "I",
-                "I"
+                "Pop",
+                "Pop"
               ],
               "properties": {
-                "name": "Infection",
-                "description": "Infective interaction between individuals"
+                "name": "Infect",
+                "description": "2-to-2 interaction that represents infectious contact between two human individuals"
               }
-            },
-            {
-              "id": "rec",
+          },
+          {
+              "id": "Disease",
               "input": [
-                "I"
+                "Pop"
               ],
               "output": [
-                "R"
+                "Pop"
               ],
               "properties": {
-                "name": "Recovery",
-                "description": "Recovery interaction of a infected individual"
+                "name": "Disease",
+                "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
               }
-            }
-        ]
-    },
-    "semantics": {
-      "ode": {
-        "rates": [
-          {
-            "target": "inf",
-            "expression": "S*I*beta",
-            "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
           },
           {
-            "target": "rec",
-            "expression": "I*gamma",
-            "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
-          }
-        ],
-        "initials": [
-          {
-            "target": "S",
-            "expression": "S0",
-            "expression_mathml": "<ci>S0</ci>"
-          },
-          {
-            "target": "I",
-            "expression": "I0",
-            "expression_mathml": "<ci>I0</ci>"
-          },
-          {
-            "target": "R",
-            "expression": "R0",
-            "expression_mathml": "<ci>R0</ci>"
-          }
-        ],
-        "parameters": [
-          {
-            "id": "beta",
-            "name": "β",
-            "description": "infection rate",
-            "value": 0.027,
-            "distribution": {
-              "type": "StandardUniform1",
-              "parameters": {
-                "minimum": 0.026,
-                "maximum": 0.028
+              "id": "Strata",
+              "input": [
+                "Pop"
+              ],
+              "output": [
+                "Pop"
+              ],
+              "properties": {
+                "name": "Strata",
+                "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
               }
-            }
           },
           {
-            "id": "gamma",
-            "name": "γ",
-            "description": "recovery rate",
-            "grounding": {
-              "identifiers": {
-                "askemo": "0000013"
+              "id": "Vaccinate",
+              "input": [
+                "Pop",
+                "Vaccine"
+              ],
+              "output": [
+                "Pop"
+              ],
+              "properties": {
+                "name": "Vaccinate",
+                "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
               }
-            },
-            "value": 0.14,
-            "distribution": {
-              "type": "StandardUniform1",
-              "parameters": {
-                "minimum": 0.1,
-                "maximum": 0.18
+          },
+          {
+              "id": "Produce_Vaccine",
+              "input": [],
+              "output": [
+                "Vaccine"
+              ],
+              "properties": {
+                "name": "Produce Vaccine",
+                "description": "0-to-1 interaction that represents the production of a single vaccine dose."
               }
-            }
-          },
-          {
-            "id": "S0",
-            "name": "S₀",
-            "description": "Total susceptible population at timestep 0",
-            "value": 1000
-          },
-          {
-            "id": "I0",
-            "name": "I₀",
-            "description": "Total infected population at timestep 0",
-            "value": 1
-          },
-          {
-            "id": "R0",
-            "name": "R₀",
-            "description": "Total recovered population at timestep 0",
-            "value": 0
           }
         ]
       },
-      "typing": {
-        "type_system": {
-          "states": [
-            {
-                "id": "Pop",
-                "name": "Pop",
-                "description": "Compartment of individuals in a human population"
-            },
-            {
-                "id": "Vaccine",
-                "name": "Vaccine",
-                "description": "Compartment of vaccine doses available for use in a vaccination campaign"
-            }
-          ],
-          "transitions": [
-            {
-                "id": "Infect",
-                "input": [
-                  "Pop",
-                  "Pop"
-                ],
-                "output": [
-                  "Pop",
-                  "Pop"
-                ],
-                "properties": {
-                  "name": "Infect",
-                  "description": "2-to-2 interaction that represents infectious contact between two human individuals"
-                }
-            },
-            {
-                "id": "Disease",
-                "input": [
-                  "Pop"
-                ],
-                "output": [
-                  "Pop"
-                ],
-                "properties": {
-                  "name": "Disease",
-                  "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
-                }
-            },
-            {
-                "id": "Strata",
-                "input": [
-                  "Pop"
-                ],
-                "output": [
-                  "Pop"
-                ],
-                "properties": {
-                  "name": "Strata",
-                  "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
-                }
-            },
-            {
-                "id": "Vaccinate",
-                "input": [
-                  "Pop",
-                  "Vaccine"
-                ],
-                "output": [
-                  "Pop"
-                ],
-                "properties": {
-                  "name": "Vaccinate",
-                  "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
-                }
-            },
-            {
-                "id": "Produce_Vaccine",
-                "input": [],
-                "output": [
-                  "Vaccine"
-                ],
-                "properties": {
-                  "name": "Produce Vaccine",
-                  "description": "0-to-1 interaction that represents the production of a single vaccine dose."
-                }
-            }
-          ]
-        },
-        "type_map": [
-          ["S", "Pop"],
-          ["I", "Pop"],
-          ["R", "Pop"],
-          ["inf", "Infect"],
-          ["rec", "Disease"]
-        ]
-      }
-    },
-    "metadata": {
-      "processed_at": 1682964953,
-      "processed_by": "mit:process-node1",
-      "variable_statements": [
-        {
-          "id": "v0",
-          "variable": {
-            "id": "v0",
-            "name": "VE",
-            "metadata": [
-              {
-                "type": "text_annotation",
-                "value": " Vaccine Effectiveness"
-              },
-              {
-                "type": "text_annotation",
-                "value": " Vaccine Effectiveness"
-              }
-            ],
-            "dkg_groundings": [],
-            "column": [
-              {
-                "id": "9-2",
-                "name": "new_persons_vaccinated",
-                "dataset": {
-                  "id": "9",
-                  "name": "usa-vaccinations.csv",
-                  "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
-                }
-              },
-              {
-                "id": "9-3",
-                "name": "cumulative_persons_vaccinated",
-                "dataset": {
-                  "id": "9",
-                  "name": "usa-vaccinations.csv",
-                  "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
-                }
-              }
-            ],
-            "paper": {
-              "id": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
-              "file_directory": "https://www.medrxiv.org/content/10.1101/2021.10.08.21264595v1",
-              "doi": "10.1101/2021.10.08.21264595"
-            },
-            "equations": []
-          },
-          "metadata": [],
-          "provenance": {
-            "method": "MIT annotation",
-            "description": "text, dataset, formula annotation (chunwei@mit.edu)"
-          }
-        }
+      "type_map": [
+        ["S", "Pop"],
+        ["I", "Pop"],
+        ["R", "Pop"],
+        ["inf", "Infect"],
+        ["rec", "Disease"]
       ]
     }
+  },
+  "metadata": {
+    "processed_at": 1682964953,
+    "processed_by": "mit:process-node1",
+    "variable_statements": [
+      {
+        "id": "v0",
+        "variable": {
+          "id": "v0",
+          "name": "VE",
+          "metadata": [
+            {
+              "type": "text_annotation",
+              "value": " Vaccine Effectiveness"
+            },
+            {
+              "type": "text_annotation",
+              "value": " Vaccine Effectiveness"
+            }
+          ],
+          "dkg_groundings": [],
+          "column": [
+            {
+              "id": "9-2",
+              "name": "new_persons_vaccinated",
+              "dataset": {
+                "id": "9",
+                "name": "usa-vaccinations.csv",
+                "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+              }
+            },
+            {
+              "id": "9-3",
+              "name": "cumulative_persons_vaccinated",
+              "dataset": {
+                "id": "9",
+                "name": "usa-vaccinations.csv",
+                "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+              }
+            }
+          ],
+          "paper": {
+            "id": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
+            "file_directory": "https://www.medrxiv.org/content/10.1101/2021.10.08.21264595v1",
+            "doi": "10.1101/2021.10.08.21264595"
+          },
+          "equations": []
+        },
+        "metadata": [],
+        "provenance": {
+          "method": "MIT annotation",
+          "description": "text, dataset, formula annotation (chunwei@mit.edu)"
+        }
+      }
+    ]
   }
+}
   

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -8,7 +8,7 @@
       {
         "id": "S",
         "name": "Susceptible",
-        "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
+        "description": "Number of individuals that are 'susceptible' to a disease infection",
         "grounding": {
           "identifiers": {
             "ido": "0000514"
@@ -18,7 +18,7 @@
       {
         "id": "I",
         "name": "Infected",
-        "description": "Number of individuals relative to the total population that are 'infected' by a disease",
+        "description": "Number of individuals that are 'infected' by a disease",
         "grounding": {
           "identifiers": {
             "ido": "0000511"
@@ -28,7 +28,7 @@
       {
         "id": "R",
         "name": "Recovered",
-        "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
+        "description": "Number of individuals that have 'recovered' from a disease infection",
         "grounding": {
           "identifiers": {
             "ido": "0000592"
@@ -49,7 +49,7 @@
         ],
         "properties": {
           "name": "Infection",
-          "description": "Infective interaction between individuals"
+          "description": "Infective process between individuals"
         }
       },
       {
@@ -62,7 +62,7 @@
         ],
         "properties": {
           "name": "Recovery",
-          "description": "Recovery interaction of a infected individual"
+          "description": "Recovery process of a infected individual"
         }
       }
     ]
@@ -177,7 +177,7 @@
               ],
               "properties": {
                 "name": "Infect",
-                "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+                "description": "2-to-2 process that represents infectious contact between two human individuals"
               }
           },
           {
@@ -190,7 +190,7 @@
               ],
               "properties": {
                 "name": "Disease",
-                "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+                "description": "1-to-1 process that represents a change in th edisease status of a human individual."
               }
           },
           {
@@ -203,7 +203,7 @@
               ],
               "properties": {
                 "name": "Strata",
-                "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+                "description": "1-to-1 process that represents a change in the demographic division of a human individual."
               }
           },
           {
@@ -217,7 +217,7 @@
               ],
               "properties": {
                 "name": "Vaccinate",
-                "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+                "description": "2-to-1 process that represents an human individual receiving a vaccine dose."
               }
           },
           {
@@ -228,7 +228,7 @@
               ],
               "properties": {
                 "name": "Produce Vaccine",
-                "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+                "description": "0-to-1 process that represents the production of a single vaccine dose."
               }
           }
         ]

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -10,9 +10,9 @@
                 "name": "Susceptible",
                 "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
                 "grounding": {
-                    "identifiers": {
+                  "identifiers": {
                     "ido": "0000514"
-                    }
+                  }
                 }
             },
             {
@@ -20,9 +20,9 @@
                 "name": "Infected",
                 "description": "Number of individuals relative to the total population that are 'infected' by a disease",
                 "grounding": {
-                    "identifiers": {
+                  "identifiers": {
                     "ido": "0000511"
-                    }
+                  }
                 }
             },
             {
@@ -30,40 +30,40 @@
                 "name": "Recovered",
                 "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
                 "grounding": {
-                    "identifiers": {
+                  "identifiers": {
                     "ido": "0000592"
-                    }
+                  }
                 }
             }
         ],
         "transitions": [
             {
-                "id": "inf",
-                "input": [
-                    "S",
-                    "I"
-                ],
-                "output": [
-                    "I",
-                    "I"
-                ],
-                "properties": {
-                    "name": "Infection",
-                    "description": "Infective interaction between individuals"
-                }
+              "id": "inf",
+              "input": [
+                "S",
+                "I"
+              ],
+              "output": [
+                "I",
+                "I"
+              ],
+              "properties": {
+                "name": "Infection",
+                "description": "Infective interaction between individuals"
+              }
             },
             {
-                "id": "rec",
-                "input": [
-                    "I"
-                ],
-                "output": [
-                    "R"
-                ],
-                "properties": {
-                    "name": "Recovery",
-                    "description": "Recovery interaction of a infected individual"
-                }
+              "id": "rec",
+              "input": [
+                "I"
+              ],
+              "output": [
+                "R"
+              ],
+              "properties": {
+                "name": "Recovery",
+                "description": "Recovery interaction of a infected individual"
+              }
             }
         ]
     },
@@ -101,6 +101,7 @@
         "parameters": [
           {
             "id": "beta",
+            "name": "β",
             "description": "infection rate",
             "value": 0.027,
             "distribution": {
@@ -113,6 +114,7 @@
           },
           {
             "id": "gamma",
+            "name": "γ",
             "description": "recovery rate",
             "grounding": {
               "identifiers": {
@@ -130,16 +132,19 @@
           },
           {
             "id": "S0",
+            "name": "S₀",
             "description": "Total susceptible population at timestep 0",
             "value": 1000
           },
           {
             "id": "I0",
+            "name": "I₀",
             "description": "Total infected population at timestep 0",
             "value": 1
           },
           {
             "id": "R0",
+            "name": "R₀",
             "description": "Total recovered population at timestep 0",
             "value": 0
           }
@@ -163,67 +168,67 @@
             {
                 "id": "Infect",
                 "input": [
-                    "Pop",
-                    "Pop"
+                  "Pop",
+                  "Pop"
                 ],
                 "output": [
-                    "Pop",
-                    "Pop"
+                  "Pop",
+                  "Pop"
                 ],
                 "properties": {
-                    "name": "Infect",
-                    "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+                  "name": "Infect",
+                  "description": "2-to-2 interaction that represents infectious contact between two human individuals"
                 }
             },
             {
                 "id": "Disease",
                 "input": [
-                    "Pop"
+                  "Pop"
                 ],
                 "output": [
-                    "Pop"
+                  "Pop"
                 ],
                 "properties": {
-                    "name": "Disease",
-                    "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+                  "name": "Disease",
+                  "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
                 }
             },
             {
                 "id": "Strata",
                 "input": [
-                    "Pop"
+                  "Pop"
                 ],
                 "output": [
-                    "Pop"
+                  "Pop"
                 ],
                 "properties": {
-                    "name": "Strata",
-                    "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+                  "name": "Strata",
+                  "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
                 }
             },
             {
                 "id": "Vaccinate",
                 "input": [
-                    "Pop",
-                    "Vaccine"
+                  "Pop",
+                  "Vaccine"
                 ],
                 "output": [
-                    "Pop"
+                  "Pop"
                 ],
                 "properties": {
-                    "name": "Vaccinate",
-                    "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+                  "name": "Vaccinate",
+                  "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
                 }
             },
             {
                 "id": "Produce_Vaccine",
                 "input": [],
                 "output": [
-                    "Vaccine"
+                  "Vaccine"
                 ],
                 "properties": {
-                    "name": "Produce Vaccine",
-                    "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+                  "name": "Produce Vaccine",
+                  "description": "0-to-1 interaction that represents the production of a single vaccine dose."
                 }
             }
           ]

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -116,6 +116,9 @@
         "name": {
           "type": "string"
         },
+        "description": {
+          "type": "string"
+        },
         "grounding": {
           "$ref": "#/$defs/grounding"
         }

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -317,6 +317,9 @@
               "id": {
                 "type": "string"
               },
+              "name": {
+                "type": "string"
+              },
               "description": {
                 "type": "string"
               },


### PR DESCRIPTION
Minor PR. Added the "id", "name", "description" properties that was missing in "transitions" and "parameters" of the Petri net schema and examples.