### PR TITLE
Add representation for time variable in models

### DIFF
--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -178,7 +178,10 @@
           "expression": "S+R",
           "expression_mathml": "<apply><plus/><ci>S</ci><ci>R</ci></apply>"
         }
-      ]
+      ],
+      "time": {
+        "id": "t"
+      }
     }
   },
   "metadata": {

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -180,7 +180,11 @@
         }
       ],
       "time": {
-        "id": "t"
+        "id": "t",
+        "units": {
+          "expression": "day",
+          "expression_mathml": "<ci>day</ci>"
+        }
       }
     }
   },

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -149,7 +149,10 @@
           "description": "Total recovered population at timestep 0",
           "value": 0
         }
-      ]
+      ],
+      "time": {
+        "id": "t"
+      }
     },
     "typing": {
       "type_system": {

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -394,7 +394,7 @@
             ]
           }
         },
-       "time": {
+        "time": {
           "type": "object",
           "properties": {
             "id": {

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -393,6 +393,17 @@
               "id"
             ]
           }
+        },
+       "time": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "required": [
+              "id"
+            ]
+          }
         }
       }
     }

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -405,7 +405,8 @@
             ]
           }
         }
-      }
+      },
+      "required": []
     }
   },
   "additionalProperties": true,

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -402,11 +402,11 @@
             },
             "units": {
               "$ref": "#/$defs/unit"
-            },
-            "required": [
-              "id"
-            ]
-          }
+            }
+          },
+          "required": [
+            "id"
+          ]
         }
       },
       "required": []

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -400,6 +400,9 @@
             "id": {
               "type": "string"
             },
+            "units": {
+              "$ref": "#/$defs/unit"
+            },
             "required": [
               "id"
             ]


### PR DESCRIPTION
This PR implements a way to declare a time variable within the odeSemantics of Petri nets. The reason this is useful is that it allows the time variable to appear in custom rate law expressions, making it possible to represent (at least some) time-varying parameters.