### PR TITLE
Add new element to metadata schema

### DIFF
--- a/metadata_schema.json
+++ b/metadata_schema.json
@@ -13,6 +13,9 @@
           "items": {
             "$ref": "#/definitions/VariableStatement"
           }
+        },
+        "annotations": {
+          "$ref": "#/definitions/Annotations"
         }
       },
       "required": [],
@@ -309,6 +312,82 @@
             "variable"
           ],
           "$id": "#/definitions/VariableStatement"
+        },
+        "Annotations": {
+          "title": "Annotations",
+          "description": "A metadata model for model-level annotations.\n\nExamples in this metadata model are taken from\nhttps://www.ebi.ac.uk/biomodels/BIOMD0000000956,\na well-annotated SIR model in the BioModels database.",
+          "type": "object",
+          "properties": {
+            "license": {
+              "title": "License",
+              "description": "Information about the licensing of the model artifact. Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, models from the BioModels databases are all licensed under the CC0 public attribution license.",
+              "example": "CC0",
+              "type": "string"
+            },
+            "authors": {
+              "title": "Authors",
+              "description": "A list of authors/creators of the model. This is not the same as the people who e.g., submitted the model to BioModels",
+              "example": [
+                {
+                  "name": "Andrea L Bertozzi"
+                },
+                {
+                  "name": "Elisa Franco"
+                },
+                {
+                  "name": "George Mohler"
+                },
+                {
+                  "name": "Martin B Short"
+                },
+                {
+                  "name": "Daniel Sledge"
+                }
+              ],
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Author"
+              }
+            },
+            "references": {
+              "title": "References",
+              "description": "A list of CURIEs (i.e., <prefix>:<identifier>) corresponding to literature references that describe the model. Do **not** duplicate the same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
+              "example": [
+                "pubmed:32616574"
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "model_types": {
+              "title": "Model Types",
+              "description": "This field describes the type(s) of the model using the Mathematical Modeling Ontology (MAMO), which has terms like 'ordinary differential equation  model', 'population model', etc. These should be annotated as CURIEs in the form of mamo:<local unique identifier>. For example, the Bertozzi 2020 model is a population model (mamo:0000028) and ordinary differential equation model (mamo:0000046)",
+              "example": [
+                "mamo:0000028",
+                "mamo:0000046"
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "Author": {
+          "title": "Author",
+          "description": "A metadata model for an author. Could be expanded to include ORCID later.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "title": "Name",
+              "description": "The name of the author",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ]
         }
       }
     }

--- a/metadata_schema.json
+++ b/metadata_schema.json
@@ -322,28 +322,32 @@
             "license": {
               "title": "License",
               "description": "Information about the licensing of the model artifact. Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, models from the BioModels databases are all licensed under the CC0 public attribution license.",
-              "example": "CC0",
+              "examples": [
+                "CC0"
+              ],
               "type": "string"
             },
             "authors": {
               "title": "Authors",
               "description": "A list of authors/creators of the model. This is not the same as the people who e.g., submitted the model to BioModels",
-              "example": [
-                {
-                  "name": "Andrea L Bertozzi"
-                },
-                {
-                  "name": "Elisa Franco"
-                },
-                {
-                  "name": "George Mohler"
-                },
-                {
-                  "name": "Martin B Short"
-                },
-                {
-                  "name": "Daniel Sledge"
-                }
+              "examples": [
+                [
+                  {
+                    "name": "Andrea L Bertozzi"
+                  },
+                  {
+                    "name": "Elisa Franco"
+                  },
+                  {
+                    "name": "George Mohler"
+                  },
+                  {
+                    "name": "Martin B Short"
+                  },
+                  {
+                    "name": "Daniel Sledge"
+                  }
+                ]
               ],
               "type": "array",
               "items": {
@@ -353,8 +357,10 @@
             "references": {
               "title": "References",
               "description": "A list of CURIEs (i.e., <prefix>:<identifier>) corresponding to literature references that describe the model. Do **not** duplicate the same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
-              "example": [
-                "pubmed:32616574"
+              "examples": [
+                [
+                  "pubmed:32616574"
+                ]
               ],
               "type": "array",
               "items": {
@@ -364,9 +370,11 @@
             "model_types": {
               "title": "Model Types",
               "description": "This field describes the type(s) of the model using the Mathematical Modeling Ontology (MAMO), which has terms like 'ordinary differential equation  model', 'population model', etc. These should be annotated as CURIEs in the form of mamo:<local unique identifier>. For example, the Bertozzi 2020 model is a population model (mamo:0000028) and ordinary differential equation model (mamo:0000046)",
-              "example": [
-                "mamo:0000028",
-                "mamo:0000046"
+              "examples": [
+                [
+                  "mamo:0000028",
+                  "mamo:0000046"
+                ]
               ],
               "type": "array",
               "items": {

--- a/metadata_schema.json
+++ b/metadata_schema.json
@@ -314,6 +314,7 @@
           "$id": "#/definitions/VariableStatement"
         },
         "Annotations": {
+          "$id": "#/definitions/Annotations",
           "title": "Annotations",
           "description": "A metadata model for model-level annotations.\n\nExamples in this metadata model are taken from\nhttps://www.ebi.ac.uk/biomodels/BIOMD0000000956,\na well-annotated SIR model in the BioModels database.",
           "type": "object",
@@ -375,6 +376,7 @@
           }
         },
         "Author": {
+          "$id": "#/definitions/Author",
           "title": "Author",
           "description": "A metadata model for an author. Could be expanded to include ORCID later.",
           "type": "object",

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -1,7 +1,7 @@
 {
   "name": "SIR Model",
   "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
-  "description": "SIR model created by Ben, Micah, Brandon",
+  "description": "SIR model",
   "model_version": "0.1",
   "model": {
     "states": [
@@ -203,6 +203,20 @@
           "description": "text, dataset, formula annotation (chunwei@mit.edu)"
         }
       }
-    ]
+    ],
+    "annotations": {
+      "license": "CC0",
+      "authors": [
+        {"name":  "Ben"},
+        {"name":  "Micah"},
+        {"name":  "Brandon"}
+      ],
+      "references": [
+        "doi:10.1101/2021.10.08.21264595"
+      ],
+      "model_types": [
+        "mamo:0000046"
+      ]
+    }
   }
 }


### PR DESCRIPTION
This PR adds a new section "annotations" (suggestions welcome for a better name) to the generic metadata schema such that artifacts describing a model from any framework, whether it's petri nets, regnets, or something else, can have more detailed model-level metadata. This includes:

1. License
2. Model type annotations from the [Mathematical Modeling Ontology (MAMO)](https://bioregistry.io/registry/mamo)
3. Author information
4. Provenance information

I also updated the SIR example for petri nets to include an example usage of these.

The "annotations" block would also be a good place to put task-specific annotations. In the epi use case, this might include host organism, pathogenic organisms, diseases, time start, time end