### PR TITLE
Add framework name (id) to schema

### DIFF
--- a/base_schema.json
+++ b/base_schema.json
@@ -15,6 +15,10 @@
       "format": "uri",
       "description": "URI of a JSON schema document that describes the model stored in the 'model' parameter."
     },
+    "framework": {
+      "type": "string",
+      "description": "The ID of the framework. E.g. `petrinet`"
+    },    
     "model": {
       "type": "object",
       "description": "JSON representation of a model. This should contain everything needed to fully run the model, including all rates/initial parameters/distributions/etc."

--- a/base_schema.json
+++ b/base_schema.json
@@ -15,9 +15,9 @@
       "format": "uri",
       "description": "URI of a JSON schema document that describes the model stored in the 'model' parameter."
     },
-    "framework": {
+    "schema_name": {
       "type": "string",
-      "description": "The ID of the framework. E.g. `petrinet`"
+      "description": "The ID of the schema name. E.g. `petrinet`"
     },    
     "model": {
       "type": "object",

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -1,7 +1,7 @@
 {
   "name": "SIR Model",
   "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
-  "framework": "petrinet",  
+  "schema_name": "petrinet",  
   "description": "SIR model created by Ben, Micah, Brandon",
   "model_version": "0.1",
   "model": {

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -1,6 +1,7 @@
 {
   "name": "SIR Model",
   "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
+  "framework": "petrinet",  
   "description": "SIR model created by Ben, Micah, Brandon",
   "model_version": "0.1",
   "model": {

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -1,7 +1,7 @@
 {
     "name": "SIR Model",
     "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
-    "framework": "petrinet",
+    "schema_name": "petrinet",
     "description": "Typed SIR model created by Nelson, derived from the one by Ben, Micah, Brandon",
     "model_version": "0.1",
     "model": {

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -1,6 +1,7 @@
 {
     "name": "SIR Model",
     "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.1/petrinet/petrinet_schema.json",
+    "framework": "petrinet",
     "description": "Typed SIR model created by Nelson, derived from the one by Ben, Micah, Brandon",
     "model_version": "0.1",
     "model": {

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -9,6 +9,9 @@
       "type": "string",
       "format": "uri"
     },
+    "framework": {
+      "type": "string"
+    },    
     "description": {
       "type": "string"
     },

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -9,7 +9,7 @@
       "type": "string",
       "format": "uri"
     },
-    "framework": {
+    "schema_name": {
       "type": "string"
     },    
     "description": {

--- a/regnet/examples/lotka_volterra.json
+++ b/regnet/examples/lotka_volterra.json
@@ -1,6 +1,7 @@
 {
   "name": "Lotka Volterra",
   "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.1/regnet/regnet_schema.json",
+  "framework": "regnet",
   "description": "Lotka Volterra model",
   "model_version": "0.1",
   "model": {

--- a/regnet/examples/lotka_volterra.json
+++ b/regnet/examples/lotka_volterra.json
@@ -1,7 +1,7 @@
 {
   "name": "Lotka Volterra",
   "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.1/regnet/regnet_schema.json",
-  "framework": "regnet",
+  "schema_name": "regnet",
   "description": "Lotka Volterra model",
   "model_version": "0.1",
   "model": {

--- a/regnet/examples/syntax_edge_cases.json
+++ b/regnet/examples/syntax_edge_cases.json
@@ -1,7 +1,7 @@
 {
   "name": "Syntax Edge Cases",
   "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.1/regnet/regnet_schema.json",
-  "framework": "regnet",  
+  "schema_name": "regnet",  
   "description": "A regulatory network to demonstrate syntactic edge cases of the JSON Schema of RegNets.",
   "model_version": "0.1",
   "model": {

--- a/regnet/examples/syntax_edge_cases.json
+++ b/regnet/examples/syntax_edge_cases.json
@@ -1,6 +1,7 @@
 {
   "name": "Syntax Edge Cases",
   "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.1/regnet/regnet_schema.json",
+  "framework": "regnet",  
   "description": "A regulatory network to demonstrate syntactic edge cases of the JSON Schema of RegNets.",
   "model_version": "0.1",
   "model": {

--- a/regnet/regnet_schema.json
+++ b/regnet/regnet_schema.json
@@ -9,6 +9,9 @@
       "type": "string",
       "format": "uri"
     },
+    "framework": {
+      "type": "string"
+    },
     "description": {
       "type": "string"
     },

--- a/regnet/regnet_schema.json
+++ b/regnet/regnet_schema.json
@@ -9,7 +9,7 @@
       "type": "string",
       "format": "uri"
     },
-    "framework": {
+    "schema_name": {
       "type": "string"
     },
     "description": {


### PR DESCRIPTION
For discussion/review during open house...

This PR adds the top level key `framework` to the model representation. This should be the string of the model framework (e.g. `petrinet` or `regnet`).

This will be useful for TA4 for search/retrieval tasks. Though it is implied by the `schema` field, having this explicitly stated will be useful to meet near term development goals. This field can be ignored by systems that do not need to use it.