### PR TITLE
WIP: Stratification of AMR Petri Nets

### DIFF
--- a/petrinet/examples/flux_typed.json
+++ b/petrinet/examples/flux_typed.json
@@ -1,0 +1,154 @@
+{
+  "name": "Two City Stratification Model",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+  "description": "Stratification spatially between two cities model created by Micah",
+  "model_version": "0.1",
+  "model": {
+    "states": [
+      {
+        "id": "Rgn_1",
+        "name": "Region 1",
+        "description": "Number of individuals physically located in region 1 relative to the total population"
+      },
+      {
+        "id": "Rgn_2",
+        "name": "Region 2",
+        "description": "Number of individuals physically located in region 2 relative to the total population"
+      }
+    ],
+    "transitions": [
+      {
+        "id": "travel_1_2",
+        "input": [
+          "Rgn_1"
+        ],
+        "output": [
+          "Rgn_2"
+        ],
+        "properties": {
+          "name": "Traveling 1 -> 2",
+          "description": "Individuals traveling from region 1 to region 2"
+        }
+      },
+      {
+        "id": "travel_2_1",
+        "input": [
+          "Rgn_2"
+        ],
+        "output": [
+          "Rgn_1"
+        ],
+        "properties": {
+          "name": "Traveling 2 -> 1",
+          "description": "Individuals traveling from region 2 to region 1"
+        }
+      }
+    ]
+  },
+  "semantics": {
+    "ode": {},
+    "typing": {
+      "type_system": {
+        "states": [
+          {
+            "id": "Pop",
+            "name": "Pop",
+            "description": "Compartment of individuals in a human population"
+          },
+          {
+            "id": "Vaccine",
+            "name": "Vaccine",
+            "description": "Compartment of vaccine doses available for use in a vaccination campaign"
+          }
+        ],
+        "transitions": [
+          {
+            "id": "Infect",
+            "input": [
+              "Pop",
+              "Pop"
+            ],
+            "output": [
+              "Pop",
+              "Pop"
+            ],
+            "properties": {
+              "name": "Infect",
+              "description": "2-to-2 process that represents infectious contact between two human individuals"
+            }
+          },
+          {
+            "id": "Disease",
+            "input": [
+              "Pop"
+            ],
+            "output": [
+              "Pop"
+            ],
+            "properties": {
+              "name": "Disease",
+              "description": "1-to-1 process that represents a change in th edisease status of a human individual."
+            }
+          },
+          {
+            "id": "Strata",
+            "input": [
+              "Pop"
+            ],
+            "output": [
+              "Pop"
+            ],
+            "properties": {
+              "name": "Strata",
+              "description": "1-to-1 process that represents a change in the demographic division of a human individual."
+            }
+          },
+          {
+            "id": "Vaccinate",
+            "input": [
+              "Pop",
+              "Vaccine"
+            ],
+            "output": [
+              "Pop"
+            ],
+            "properties": {
+              "name": "Vaccinate",
+              "description": "2-to-1 process that represents an human individual receiving a vaccine dose."
+            }
+          },
+          {
+            "id": "Produce_Vaccine",
+            "input": [],
+            "output": [
+              "Vaccine"
+            ],
+            "properties": {
+              "name": "Produce Vaccine",
+              "description": "0-to-1 process that represents the production of a single vaccine dose."
+            }
+          }
+        ]
+      },
+      "type_map": [
+        [
+          "Rgn_1",
+          "Pop"
+        ],
+        [
+          "Rgn_2",
+          "Pop"
+        ],
+        [
+          "travel_1_2",
+          "Strata"
+        ],
+        [
+          "travel_2_1",
+          "Strata"
+        ]
+      ]
+    }
+  },
+  "metadata": {}
+}

--- a/petrinet/examples/flux_typed_aug.json
+++ b/petrinet/examples/flux_typed_aug.json
@@ -1,7 +1,7 @@
 {
   "name": "Two City Stratification Model",
   "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
-  "description": "Stratification spatially between two cities model created by Micah. Modified by Patrick.",
+  "description": "Stratification spatially between two cities model created by Micah",
   "model_version": "0.1",
   "model": {
     "states": [
@@ -17,6 +17,38 @@
       }
     ],
     "transitions": [
+      {
+        "id": "Rgn1_dis",
+        "input": ["Rgn_1"],
+        "output": ["Rgn_1"],
+        "properties": {
+          "name": "Rgn1_disease"
+        }
+      },
+      {
+        "id": "Rgn1_inf",
+        "input": ["Rgn_1", "Rgn_1"],
+        "output": ["Rgn_1", "Rgn_1"],
+        "properties": {
+          "name": "Rgn1_infection"
+        }
+      },
+      {
+        "id": "Rgn2_dis",
+        "input": ["Rgn_2"],
+        "output": ["Rgn_2"],
+        "properties": {
+          "name": "Rgn2_disease"
+        }
+      },
+      {
+        "id": "Rgn2_inf",
+        "input": ["Rgn_2", "Rgn_2"],
+        "output": ["Rgn_2", "Rgn_2"],
+        "properties": {
+          "name": "Rgn2_infection"
+        }
+      },
       {
         "id": "travel_1_2",
         "input": ["Rgn_1"],
@@ -112,6 +144,10 @@
       "map": [
         ["Rgn_1", "Pop"],
         ["Rgn_2", "Pop"],
+        ["Rgn1_dis", "Disease"],
+        ["Rgn1_inf", "Infect"],
+        ["Rgn2_dis", "Disease"],
+        ["Rgn2_inf", "Infect"],
         ["travel_1_2", "Strata"],
         ["travel_2_1", "Strata"]
       ]

--- a/petrinet/examples/ont_pop_vax.json
+++ b/petrinet/examples/ont_pop_vax.json
@@ -1,0 +1,69 @@
+{
+  "name": "Ontology Model w/ Pop and Vax States",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+  "description": "Ontology Model w/ Population and Vaccine-Unit States. File created by Patrick based ontology created by Nelson",
+  "model_version": "0.1",
+  "model": {
+    "states": [
+      {
+        "id": "Pop",
+        "name": "Pop",
+        "description": "Compartment of individuals in a human population"
+      },
+      {
+        "id": "Vaccine",
+        "name": "Vaccine",
+        "description": "Compartment of vaccine doses available for use in a vaccination campaign"
+      }
+    ],
+    "transitions": [
+      {
+        "id": "Infect",
+        "input": ["Pop", "Pop"],
+        "output": ["Pop", "Pop"],
+        "properties": {
+          "name": "Infect",
+          "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+        }
+      },
+      {
+        "id": "Disease",
+        "input": ["Pop"],
+        "output": ["Pop"],
+        "properties": {
+          "name": "Disease",
+          "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+        }
+      },
+      {
+        "id": "Strata",
+        "input": ["Pop"],
+        "output": ["Pop"],
+        "properties": {
+          "name": "Strata",
+          "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+        }
+      },
+      {
+        "id": "Vaccinate",
+        "input": ["Pop", "Vaccine"],
+        "output": ["Pop"],
+        "properties": {
+          "name": "Vaccinate",
+          "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+        }
+      },
+      {
+        "id": "Produce_Vaccine",
+        "input": [],
+        "output": ["Vaccine"],
+        "properties": {
+          "name": "Produce Vaccine",
+          "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+        }
+      }
+    ]
+  },
+  "semantics": {},
+  "metadata": {}
+}

--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -52,14 +52,8 @@
     "transitions": [
       {
         "id": "inf",
-        "input": [
-          "S",
-          "I"
-        ],
-        "output": [
-          "I",
-          "I"
-        ],
+        "input": ["S", "I"],
+        "output": ["I", "I"],
         "properties": {
           "name": "Infection",
           "description": "Infective process between individuals"
@@ -67,12 +61,8 @@
       },
       {
         "id": "rec",
-        "input": [
-          "I"
-        ],
-        "output": [
-          "R"
-        ],
+        "input": ["I"],
+        "output": ["R"],
         "properties": {
           "name": "Recovery",
           "description": "Recovery process of a infected individual"
@@ -174,10 +164,7 @@
         {
           "id": "noninf",
           "name": "Non-infectious",
-          "states": [
-            "S",
-            "R"
-          ],
+          "states": ["S", "R"],
           "expression": "S+R",
           "expression_mathml": "<apply><plus/><ci>S</ci><ci>R</ci></apply>"
         }

--- a/petrinet/examples/sir_flux_span.json
+++ b/petrinet/examples/sir_flux_span.json
@@ -1,0 +1,654 @@
+{
+  "name": "SIR-Two-City-Flux Stratified Model",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+  "description": "SIR disease model stratified spatially between two cities model created by Patrick",
+  "model_version": "0.1",
+  "model": {
+    "states": [
+      {
+        "id": "S1",
+        "name": "S_Rgn1",
+        "grounding": {
+          "identifiers": {
+            "ido": "a"
+          }
+        }
+      },
+      {
+        "id": "I1",
+        "name": "I_Rgn1",
+        "grounding": {
+          "identifiers": {
+            "ido": "b"
+          }
+        }
+      },
+      {
+        "id": "R1",
+        "name": "R_Rgn1",
+        "grounding": {
+          "identifiers": {
+            "ido": "c"
+          }
+        }
+      },
+      {
+        "id": "S2",
+        "name": "S_Rgn2",
+        "grounding": {
+          "identifiers": {
+            "ido": "d"
+          }
+        }
+      },
+      {
+        "id": "I2",
+        "name": "I_Rgn2",
+        "grounding": {
+          "identifiers": {
+            "ido": "e"
+          }
+        }
+      },
+      {
+        "id": "R2",
+        "name": "R_Rgn2",
+        "grounding": {
+          "identifiers": {
+            "ido": "f"
+          }
+        }
+      }
+    ],
+    "transitions": [
+      {
+        "id": "inf1",
+        "input": ["S1", "I1"],
+        "output": ["I1", "I1"],
+        "properties": {
+          "name": "g"
+        }
+      },
+      {
+        "id": "rec1",
+        "input": ["I1"],
+        "output": ["R1"],
+        "properties": {
+          "name": "h"
+        }
+      },
+      {
+        "id": "inf2",
+        "input": ["S2", "I2"],
+        "output": ["I2", "I2"],
+        "properties": {
+          "name": "i"
+        }
+      },
+      {
+        "id": "rec2",
+        "input": ["I2"],
+        "output": ["R2"],
+        "properties": {
+          "name": "j"
+        }
+      },
+      {
+        "id": "S_travel_1_2",
+        "input": ["S1"],
+        "output": ["S2"],
+        "properties": {
+          "name": "k",
+          "description": "l"
+        }
+      },
+      {
+        "id": "S_travel_2_1",
+        "input": ["S2"],
+        "output": ["S1"],
+        "properties": {
+          "name": "m",
+          "description": "n"
+        }
+      },
+      {
+        "id": "I_travel_1_2",
+        "input": ["I1"],
+        "output": ["I2"],
+        "properties": {
+          "name": "o",
+          "description": "p"
+        }
+      },
+      {
+        "id": "I_travel_2_1",
+        "input": ["I2"],
+        "output": ["I1"],
+        "properties": {
+          "name": "q",
+          "description": "r"
+        }
+      },
+      {
+        "id": "R_travel_1_2",
+        "input": ["R1"],
+        "output": ["R2"],
+        "properties": {
+          "name": "s",
+          "description": "t"
+        }
+      },
+      {
+        "id": "R_travel_2_1",
+        "input": ["R2"],
+        "output": ["R1"],
+        "properties": {
+          "name": "u",
+          "description": "v"
+        }
+      }
+    ]
+  },
+  "semantics": {
+    "ode": {},
+    "span": [
+      {
+        "system": {
+          "name": "SIR Model",
+          "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+          "description": "Typed SIR model created by Nelson, derived from the one by Ben, Micah, Brandon",
+          "model_version": "0.1",
+          "model": {
+            "states": [
+              {
+                "id": "S",
+                "name": "Susceptible",
+                "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
+                "grounding": {
+                  "identifiers": {
+                    "ido": "0000514"
+                  }
+                }
+              },
+              {
+                "id": "I",
+                "name": "Infected",
+                "description": "Number of individuals relative to the total population that are 'infected' by a disease",
+                "grounding": {
+                  "identifiers": {
+                    "ido": "0000511"
+                  }
+                }
+              },
+              {
+                "id": "R",
+                "name": "Recovered",
+                "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
+                "grounding": {
+                  "identifiers": {
+                    "ido": "0000592"
+                  }
+                }
+              }
+            ],
+            "transitions": [
+              {
+                "id": "inf",
+                "input": ["S", "I"],
+                "output": ["I", "I"],
+                "properties": {
+                  "name": "Infection",
+                  "description": "Infective interaction between individuals"
+                }
+              },
+              {
+                "id": "rec",
+                "input": ["I"],
+                "output": ["R"],
+                "properties": {
+                  "name": "Recovery",
+                  "description": "Recovery interaction of a infected individual"
+                }
+              },
+              {
+                "id": "S_strata",
+                "input": ["S"],
+                "output": ["S"],
+                "properties": {
+                  "name": "S_strata"
+                }
+              },
+              {
+                "id": "I_strata",
+                "input": ["I"],
+                "output": ["I"],
+                "properties": {
+                  "name": "I_strata"
+                }
+              },
+              {
+                "id": "R_strata",
+                "input": ["R"],
+                "output": ["R"],
+                "properties": {
+                  "name": "R_strata"
+                }
+              }
+            ]
+          },
+          "semantics": {
+            "ode": {
+              "rates": [
+                {
+                  "target": "inf",
+                  "expression": "S*I*beta",
+                  "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
+                },
+                {
+                  "target": "rec",
+                  "expression": "I*gamma",
+                  "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
+                }
+              ],
+              "initials": [
+                {
+                  "target": "S",
+                  "expression": "S0",
+                  "expression_mathml": "<ci>S0</ci>"
+                },
+                {
+                  "target": "I",
+                  "expression": "I0",
+                  "expression_mathml": "<ci>I0</ci>"
+                },
+                {
+                  "target": "R",
+                  "expression": "R0",
+                  "expression_mathml": "<ci>R0</ci>"
+                }
+              ],
+              "parameters": [
+                {
+                  "id": "beta",
+                  "description": "infection rate",
+                  "value": 0.027,
+                  "distribution": {
+                    "type": "StandardUniform1",
+                    "parameters": {
+                      "minimum": 0.026,
+                      "maximum": 0.028
+                    }
+                  }
+                },
+                {
+                  "id": "gamma",
+                  "description": "recovery rate",
+                  "grounding": {
+                    "identifiers": {
+                      "askemo": "0000013"
+                    }
+                  },
+                  "value": 0.14,
+                  "distribution": {
+                    "type": "StandardUniform1",
+                    "parameters": {
+                      "minimum": 0.1,
+                      "maximum": 0.18
+                    }
+                  }
+                },
+                {
+                  "id": "S0",
+                  "description": "Total susceptible population at timestep 0",
+                  "value": 1000
+                },
+                {
+                  "id": "I0",
+                  "description": "Total infected population at timestep 0",
+                  "value": 1
+                },
+                {
+                  "id": "R0",
+                  "description": "Total recovered population at timestep 0",
+                  "value": 0
+                }
+              ]
+            },
+            "typing": {
+              "system": {
+                "name": "Ontology Model w/ Pop and Vax States",
+                "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+                "description": "Ontology Model w/ Population and Vaccine-Unit States. File created by Patrick based ontology created by Nelson",
+                "model_version": "0.1",
+                "model": {
+                  "states": [
+                    {
+                      "id": "Pop",
+                      "name": "Pop",
+                      "description": "Compartment of individuals in a human population"
+                    },
+                    {
+                      "id": "Vaccine",
+                      "name": "Vaccine",
+                      "description": "Compartment of vaccine doses available for use in a vaccination campaign"
+                    }
+                  ],
+                  "transitions": [
+                    {
+                      "id": "Infect",
+                      "input": ["Pop", "Pop"],
+                      "output": ["Pop", "Pop"],
+                      "properties": {
+                        "name": "Infect",
+                        "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+                      }
+                    },
+                    {
+                      "id": "Disease",
+                      "input": ["Pop"],
+                      "output": ["Pop"],
+                      "properties": {
+                        "name": "Disease",
+                        "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+                      }
+                    },
+                    {
+                      "id": "Strata",
+                      "input": ["Pop"],
+                      "output": ["Pop"],
+                      "properties": {
+                        "name": "Strata",
+                        "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+                      }
+                    },
+                    {
+                      "id": "Vaccinate",
+                      "input": ["Pop", "Vaccine"],
+                      "output": ["Pop"],
+                      "properties": {
+                        "name": "Vaccinate",
+                        "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+                      }
+                    },
+                    {
+                      "id": "Produce_Vaccine",
+                      "input": [],
+                      "output": ["Vaccine"],
+                      "properties": {
+                        "name": "Produce Vaccine",
+                        "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+                      }
+                    }
+                  ]
+                },
+                "semantics": {},
+                "metadata": {}
+              },
+              "map": [
+                ["S", "Pop"],
+                ["I", "Pop"],
+                ["R", "Pop"],
+                ["inf", "Infect"],
+                ["rec", "Disease"],
+                ["S_strata", "Strata"],
+                ["I_strata", "Strata"],
+                ["R_strata", "Strata"]
+              ]
+            }
+          },
+          "metadata": {
+            "processed_at": 1682964953,
+            "processed_by": "mit:process-node1",
+            "variable_statements": [
+              {
+                "id": "v0",
+                "variable": {
+                  "id": "v0",
+                  "name": "VE",
+                  "metadata": [
+                    {
+                      "type": "text_annotation",
+                      "value": " Vaccine Effectiveness"
+                    },
+                    {
+                      "type": "text_annotation",
+                      "value": " Vaccine Effectiveness"
+                    }
+                  ],
+                  "dkg_groundings": [],
+                  "column": [
+                    {
+                      "id": "9-2",
+                      "name": "new_persons_vaccinated",
+                      "dataset": {
+                        "id": "9",
+                        "name": "usa-vaccinations.csv",
+                        "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+                      }
+                    },
+                    {
+                      "id": "9-3",
+                      "name": "cumulative_persons_vaccinated",
+                      "dataset": {
+                        "id": "9",
+                        "name": "usa-vaccinations.csv",
+                        "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+                      }
+                    }
+                  ],
+                  "paper": {
+                    "id": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
+                    "file_directory": "https://www.medrxiv.org/content/10.1101/2021.10.08.21264595v1",
+                    "doi": "10.1101/2021.10.08.21264595"
+                  },
+                  "equations": []
+                },
+                "metadata": [],
+                "provenance": {
+                  "method": "MIT annotation",
+                  "description": "text, dataset, formula annotation (chunwei@mit.edu)"
+                }
+              }
+            ]
+          }
+        },
+        "map": [
+          ["S1", "S"],
+          ["I1", "I"],
+          ["R1", "R"],
+          ["S2", "S"],
+          ["I2", "I"],
+          ["R2", "R"],
+          ["inf1", "inf"],
+          ["rec1", "rec"],
+          ["inf2", "inf"],
+          ["rec2", "rec"],
+          ["S_travel_1_2", "S_strata"],
+          ["S_travel_2_1", "S_strata"],
+          ["I_travel_1_2", "I_strata"],
+          ["I_travel_2_1", "I_strata"],
+          ["R_travel_1_2", "R_strata"],
+          ["R_travel_2_1", "R_strata"]
+        ]
+      },
+      {
+        "system": {
+          "name": "Two City Stratification Model",
+          "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+          "description": "Stratification spatially between two cities model created by Micah",
+          "model_version": "0.1",
+          "model": {
+            "states": [
+              {
+                "id": "Rgn_1",
+                "name": "Region 1",
+                "description": "Number of individuals physically located in region 1 relative to the total population"
+              },
+              {
+                "id": "Rgn_2",
+                "name": "Region 2",
+                "description": "Number of individuals physically located in region 2 relative to the total population"
+              }
+            ],
+            "transitions": [
+              {
+                "id": "Rgn1_dis",
+                "input": ["Rgn_1"],
+                "output": ["Rgn_1"],
+                "properties": {
+                  "name": "Rgn1_disease"
+                }
+              },
+              {
+                "id": "Rgn1_inf",
+                "input": ["Rgn_1", "Rgn_1"],
+                "output": ["Rgn_1", "Rgn_1"],
+                "properties": {
+                  "name": "Rgn1_infection"
+                }
+              },
+              {
+                "id": "Rgn2_dis",
+                "input": ["Rgn_2"],
+                "output": ["Rgn_2"],
+                "properties": {
+                  "name": "Rgn2_disease"
+                }
+              },
+              {
+                "id": "Rgn2_inf",
+                "input": ["Rgn_2", "Rgn_2"],
+                "output": ["Rgn_2", "Rgn_2"],
+                "properties": {
+                  "name": "Rgn2_infection"
+                }
+              },
+              {
+                "id": "travel_1_2",
+                "input": ["Rgn_1"],
+                "output": ["Rgn_2"],
+                "properties": {
+                  "name": "Traveling 1 -> 2",
+                  "description": "Individuals traveling from region 1 to region 2"
+                }
+              },
+              {
+                "id": "travel_2_1",
+                "input": ["Rgn_2"],
+                "output": ["Rgn_1"],
+                "properties": {
+                  "name": "Traveling 2 -> 1",
+                  "description": "Individuals traveling from region 2 to region 1"
+                }
+              }
+            ]
+          },
+          "semantics": {
+            "ode": {},
+            "typing": {
+              "system": {
+                "name": "Ontology Model w/ Pop and Vax States",
+                "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+                "description": "Ontology Model w/ Population and Vaccine-Unit States. File created by Patrick based ontology created by Nelson",
+                "model_version": "0.1",
+                "model": {
+                  "states": [
+                    {
+                      "id": "Pop",
+                      "name": "Pop",
+                      "description": "Compartment of individuals in a human population"
+                    },
+                    {
+                      "id": "Vaccine",
+                      "name": "Vaccine",
+                      "description": "Compartment of vaccine doses available for use in a vaccination campaign"
+                    }
+                  ],
+                  "transitions": [
+                    {
+                      "id": "Infect",
+                      "input": ["Pop", "Pop"],
+                      "output": ["Pop", "Pop"],
+                      "properties": {
+                        "name": "Infect",
+                        "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+                      }
+                    },
+                    {
+                      "id": "Disease",
+                      "input": ["Pop"],
+                      "output": ["Pop"],
+                      "properties": {
+                        "name": "Disease",
+                        "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+                      }
+                    },
+                    {
+                      "id": "Strata",
+                      "input": ["Pop"],
+                      "output": ["Pop"],
+                      "properties": {
+                        "name": "Strata",
+                        "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+                      }
+                    },
+                    {
+                      "id": "Vaccinate",
+                      "input": ["Pop", "Vaccine"],
+                      "output": ["Pop"],
+                      "properties": {
+                        "name": "Vaccinate",
+                        "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+                      }
+                    },
+                    {
+                      "id": "Produce_Vaccine",
+                      "input": [],
+                      "output": ["Vaccine"],
+                      "properties": {
+                        "name": "Produce Vaccine",
+                        "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+                      }
+                    }
+                  ]
+                },
+                "semantics": {},
+                "metadata": {}
+              },
+              "map": [
+                ["Rgn_1", "Pop"],
+                ["Rgn_2", "Pop"],
+                ["Rgn1_dis", "Disease"],
+                ["Rgn1_inf", "Infect"],
+                ["Rgn2_dis", "Disease"],
+                ["Rgn2_inf", "Infect"],
+                ["travel_1_2", "Strata"],
+                ["travel_2_1", "Strata"]
+              ]
+            }
+          },
+          "metadata": {}
+        },
+        "map": [
+          ["S1", "Rgn_1"],
+          ["I1", "Rgn_1"],
+          ["R1", "Rgn_1"],
+          ["S2", "Rgn_2"],
+          ["I2", "Rgn_2"],
+          ["R2", "Rgn_2"],
+          ["inf1", "Rgn1_inf"],
+          ["rec1", "Rgn1_dis"],
+          ["inf2", "Rgn2_inf"],
+          ["rec2", "Rgn2_dis"],
+          ["S_travel_1_2", "travel_1_2"],
+          ["S_travel_2_1", "travel_2_1"],
+          ["I_travel_1_2", "travel_1_2"],
+          ["I_travel_2_1", "travel_2_1"],
+          ["R_travel_1_2", "travel_1_2"],
+          ["R_travel_2_1", "travel_2_1"]
+        ]
+      }
+    ]
+  },
+  "metadata": {}
+}

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -158,91 +158,106 @@
       "type_system": {
         "states": [
           {
-              "id": "Pop",
-              "name": "Pop",
-              "description": "Compartment of individuals in a human population"
+            "id": "Pop",
+            "name": "Pop",
+            "description": "Compartment of individuals in a human population"
           },
           {
-              "id": "Vaccine",
-              "name": "Vaccine",
-              "description": "Compartment of vaccine doses available for use in a vaccination campaign"
+            "id": "Vaccine",
+            "name": "Vaccine",
+            "description": "Compartment of vaccine doses available for use in a vaccination campaign"
           }
         ],
         "transitions": [
           {
-              "id": "Infect",
-              "input": [
-                "Pop",
-                "Pop"
-              ],
-              "output": [
-                "Pop",
-                "Pop"
-              ],
-              "properties": {
-                "name": "Infect",
-                "description": "2-to-2 process that represents infectious contact between two human individuals"
-              }
+            "id": "Infect",
+            "input": [
+              "Pop",
+              "Pop"
+            ],
+            "output": [
+              "Pop",
+              "Pop"
+            ],
+            "properties": {
+              "name": "Infect",
+              "description": "2-to-2 process that represents infectious contact between two human individuals"
+            }
           },
           {
-              "id": "Disease",
-              "input": [
-                "Pop"
-              ],
-              "output": [
-                "Pop"
-              ],
-              "properties": {
-                "name": "Disease",
-                "description": "1-to-1 process that represents a change in th edisease status of a human individual."
-              }
+            "id": "Disease",
+            "input": [
+              "Pop"
+            ],
+            "output": [
+              "Pop"
+            ],
+            "properties": {
+              "name": "Disease",
+              "description": "1-to-1 process that represents a change in th edisease status of a human individual."
+            }
           },
           {
-              "id": "Strata",
-              "input": [
-                "Pop"
-              ],
-              "output": [
-                "Pop"
-              ],
-              "properties": {
-                "name": "Strata",
-                "description": "1-to-1 process that represents a change in the demographic division of a human individual."
-              }
+            "id": "Strata",
+            "input": [
+              "Pop"
+            ],
+            "output": [
+              "Pop"
+            ],
+            "properties": {
+              "name": "Strata",
+              "description": "1-to-1 process that represents a change in the demographic division of a human individual."
+            }
           },
           {
-              "id": "Vaccinate",
-              "input": [
-                "Pop",
-                "Vaccine"
-              ],
-              "output": [
-                "Pop"
-              ],
-              "properties": {
-                "name": "Vaccinate",
-                "description": "2-to-1 process that represents an human individual receiving a vaccine dose."
-              }
+            "id": "Vaccinate",
+            "input": [
+              "Pop",
+              "Vaccine"
+            ],
+            "output": [
+              "Pop"
+            ],
+            "properties": {
+              "name": "Vaccinate",
+              "description": "2-to-1 process that represents an human individual receiving a vaccine dose."
+            }
           },
           {
-              "id": "Produce_Vaccine",
-              "input": [],
-              "output": [
-                "Vaccine"
-              ],
-              "properties": {
-                "name": "Produce Vaccine",
-                "description": "0-to-1 process that represents the production of a single vaccine dose."
-              }
+            "id": "Produce_Vaccine",
+            "input": [],
+            "output": [
+              "Vaccine"
+            ],
+            "properties": {
+              "name": "Produce Vaccine",
+              "description": "0-to-1 process that represents the production of a single vaccine dose."
+            }
           }
         ]
       },
       "type_map": [
-        ["S", "Pop"],
-        ["I", "Pop"],
-        ["R", "Pop"],
-        ["inf", "Infect"],
-        ["rec", "Disease"]
+        [
+          "S",
+          "Pop"
+        ],
+        [
+          "I",
+          "Pop"
+        ],
+        [
+          "R",
+          "Pop"
+        ],
+        [
+          "inf",
+          "Infect"
+        ],
+        [
+          "rec",
+          "Disease"
+        ]
       ]
     }
   },
@@ -702,4 +717,3 @@
     ]
   }
 }
-  

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -40,14 +40,8 @@
     "transitions": [
       {
         "id": "inf",
-        "input": [
-          "S",
-          "I"
-        ],
-        "output": [
-          "I",
-          "I"
-        ],
+        "input": ["S", "I"],
+        "output": ["I", "I"],
         "properties": {
           "name": "Infection",
           "description": "Infective process between individuals"
@@ -55,12 +49,8 @@
       },
       {
         "id": "rec",
-        "input": [
-          "I"
-        ],
-        "output": [
-          "R"
-        ],
+        "input": ["I"],
+        "output": ["R"],
         "properties": {
           "name": "Recovery",
           "description": "Recovery process of a infected individual"
@@ -155,109 +145,81 @@
       }
     },
     "typing": {
-      "type_system": {
-        "states": [
-          {
-            "id": "Pop",
-            "name": "Pop",
-            "description": "Compartment of individuals in a human population"
-          },
-          {
-            "id": "Vaccine",
-            "name": "Vaccine",
-            "description": "Compartment of vaccine doses available for use in a vaccination campaign"
-          }
-        ],
-        "transitions": [
-          {
-            "id": "Infect",
-            "input": [
-              "Pop",
-              "Pop"
-            ],
-            "output": [
-              "Pop",
-              "Pop"
-            ],
-            "properties": {
-              "name": "Infect",
-              "description": "2-to-2 process that represents infectious contact between two human individuals"
+      "system": {
+        "name": "Ontology Model w/ Pop and Vax States",
+        "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+        "description": "Ontology Model w/ Population and Vaccine-Unit States. File created by Patrick based ontology created by Nelson",
+        "model_version": "0.1",
+        "model": {
+          "states": [
+            {
+              "id": "Pop",
+              "name": "Pop",
+              "description": "Compartment of individuals in a human population"
+            },
+            {
+              "id": "Vaccine",
+              "name": "Vaccine",
+              "description": "Compartment of vaccine doses available for use in a vaccination campaign"
             }
-          },
-          {
-            "id": "Disease",
-            "input": [
-              "Pop"
-            ],
-            "output": [
-              "Pop"
-            ],
-            "properties": {
-              "name": "Disease",
-              "description": "1-to-1 process that represents a change in th edisease status of a human individual."
+          ],
+          "transitions": [
+            {
+              "id": "Infect",
+              "input": ["Pop", "Pop"],
+              "output": ["Pop", "Pop"],
+              "properties": {
+                "name": "Infect",
+                "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+              }
+            },
+            {
+              "id": "Disease",
+              "input": ["Pop"],
+              "output": ["Pop"],
+              "properties": {
+                "name": "Disease",
+                "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+              }
+            },
+            {
+              "id": "Strata",
+              "input": ["Pop"],
+              "output": ["Pop"],
+              "properties": {
+                "name": "Strata",
+                "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+              }
+            },
+            {
+              "id": "Vaccinate",
+              "input": ["Pop", "Vaccine"],
+              "output": ["Pop"],
+              "properties": {
+                "name": "Vaccinate",
+                "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+              }
+            },
+            {
+              "id": "Produce_Vaccine",
+              "input": [],
+              "output": ["Vaccine"],
+              "properties": {
+                "name": "Produce Vaccine",
+                "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+              }
             }
-          },
-          {
-            "id": "Strata",
-            "input": [
-              "Pop"
-            ],
-            "output": [
-              "Pop"
-            ],
-            "properties": {
-              "name": "Strata",
-              "description": "1-to-1 process that represents a change in the demographic division of a human individual."
-            }
-          },
-          {
-            "id": "Vaccinate",
-            "input": [
-              "Pop",
-              "Vaccine"
-            ],
-            "output": [
-              "Pop"
-            ],
-            "properties": {
-              "name": "Vaccinate",
-              "description": "2-to-1 process that represents an human individual receiving a vaccine dose."
-            }
-          },
-          {
-            "id": "Produce_Vaccine",
-            "input": [],
-            "output": [
-              "Vaccine"
-            ],
-            "properties": {
-              "name": "Produce Vaccine",
-              "description": "0-to-1 process that represents the production of a single vaccine dose."
-            }
-          }
-        ]
+          ]
+        },
+        "semantics": {},
+        "metadata": {}
       },
-      "type_map": [
-        [
-          "S",
-          "Pop"
-        ],
-        [
-          "I",
-          "Pop"
-        ],
-        [
-          "R",
-          "Pop"
-        ],
-        [
-          "inf",
-          "Infect"
-        ],
-        [
-          "rec",
-          "Disease"
-        ]
+      "map": [
+        ["S", "Pop"],
+        ["I", "Pop"],
+        ["R", "Pop"],
+        ["inf", "Infect"],
+        ["rec", "Disease"]
       ]
     }
   },

--- a/petrinet/examples/sir_typed_aug.json
+++ b/petrinet/examples/sir_typed_aug.json
@@ -1,0 +1,299 @@
+{
+  "name": "SIR Model",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+  "description": "Typed SIR model created by Nelson, derived from the one by Ben, Micah, Brandon",
+  "model_version": "0.1",
+  "model": {
+    "states": [
+      {
+        "id": "S",
+        "name": "Susceptible",
+        "description": "Number of individuals relative to the total population that are 'susceptible' to a disease infection",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000514"
+          }
+        }
+      },
+      {
+        "id": "I",
+        "name": "Infected",
+        "description": "Number of individuals relative to the total population that are 'infected' by a disease",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000511"
+          }
+        }
+      },
+      {
+        "id": "R",
+        "name": "Recovered",
+        "description": "Number of individuals relative to the total population that have 'recovered' from a disease infection",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000592"
+          }
+        }
+      }
+    ],
+    "transitions": [
+      {
+        "id": "inf",
+        "input": ["S", "I"],
+        "output": ["I", "I"],
+        "properties": {
+          "name": "Infection",
+          "description": "Infective interaction between individuals"
+        }
+      },
+      {
+        "id": "rec",
+        "input": ["I"],
+        "output": ["R"],
+        "properties": {
+          "name": "Recovery",
+          "description": "Recovery interaction of a infected individual"
+        }
+      },
+      {
+        "id": "S_strata",
+        "input": ["S"],
+        "output": ["S"],
+        "properties": {
+          "name": "S_strata"
+        }
+      },
+      {
+        "id": "I_strata",
+        "input": ["I"],
+        "output": ["I"],
+        "properties": {
+          "name": "I_strata"
+        }
+      },
+      {
+        "id": "R_strata",
+        "input": ["R"],
+        "output": ["R"],
+        "properties": {
+          "name": "R_strata"
+        }
+      }
+    ]
+  },
+  "semantics": {
+    "ode": {
+      "rates": [
+        {
+          "target": "inf",
+          "expression": "S*I*beta",
+          "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
+        },
+        {
+          "target": "rec",
+          "expression": "I*gamma",
+          "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
+        }
+      ],
+      "initials": [
+        {
+          "target": "S",
+          "expression": "S0",
+          "expression_mathml": "<ci>S0</ci>"
+        },
+        {
+          "target": "I",
+          "expression": "I0",
+          "expression_mathml": "<ci>I0</ci>"
+        },
+        {
+          "target": "R",
+          "expression": "R0",
+          "expression_mathml": "<ci>R0</ci>"
+        }
+      ],
+      "parameters": [
+        {
+          "id": "beta",
+          "description": "infection rate",
+          "value": 0.027,
+          "distribution": {
+            "type": "StandardUniform1",
+            "parameters": {
+              "minimum": 0.026,
+              "maximum": 0.028
+            }
+          }
+        },
+        {
+          "id": "gamma",
+          "description": "recovery rate",
+          "grounding": {
+            "identifiers": {
+              "askemo": "0000013"
+            }
+          },
+          "value": 0.14,
+          "distribution": {
+            "type": "StandardUniform1",
+            "parameters": {
+              "minimum": 0.1,
+              "maximum": 0.18
+            }
+          }
+        },
+        {
+          "id": "S0",
+          "description": "Total susceptible population at timestep 0",
+          "value": 1000
+        },
+        {
+          "id": "I0",
+          "description": "Total infected population at timestep 0",
+          "value": 1
+        },
+        {
+          "id": "R0",
+          "description": "Total recovered population at timestep 0",
+          "value": 0
+        }
+      ]
+    },
+    "typing": {
+      "system": {
+        "name": "Ontology Model w/ Pop and Vax States",
+        "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+        "description": "Ontology Model w/ Population and Vaccine-Unit States. File created by Patrick based ontology created by Nelson",
+        "model_version": "0.1",
+        "model": {
+          "states": [
+            {
+              "id": "Pop",
+              "name": "Pop",
+              "description": "Compartment of individuals in a human population"
+            },
+            {
+              "id": "Vaccine",
+              "name": "Vaccine",
+              "description": "Compartment of vaccine doses available for use in a vaccination campaign"
+            }
+          ],
+          "transitions": [
+            {
+              "id": "Infect",
+              "input": ["Pop", "Pop"],
+              "output": ["Pop", "Pop"],
+              "properties": {
+                "name": "Infect",
+                "description": "2-to-2 interaction that represents infectious contact between two human individuals"
+              }
+            },
+            {
+              "id": "Disease",
+              "input": ["Pop"],
+              "output": ["Pop"],
+              "properties": {
+                "name": "Disease",
+                "description": "1-to-1 interaction that represents a change in th edisease status of a human individual."
+              }
+            },
+            {
+              "id": "Strata",
+              "input": ["Pop"],
+              "output": ["Pop"],
+              "properties": {
+                "name": "Strata",
+                "description": "1-to-1 interaction that represents a change in the demographic division of a human individual."
+              }
+            },
+            {
+              "id": "Vaccinate",
+              "input": ["Pop", "Vaccine"],
+              "output": ["Pop"],
+              "properties": {
+                "name": "Vaccinate",
+                "description": "2-to-1 interaction that represents an human individual receiving a vaccine dose."
+              }
+            },
+            {
+              "id": "Produce_Vaccine",
+              "input": [],
+              "output": ["Vaccine"],
+              "properties": {
+                "name": "Produce Vaccine",
+                "description": "0-to-1 interaction that represents the production of a single vaccine dose."
+              }
+            }
+          ]
+        },
+        "semantics": {},
+        "metadata": {}
+      },
+      "map": [
+        ["S", "Pop"],
+        ["I", "Pop"],
+        ["R", "Pop"],
+        ["inf", "Infect"],
+        ["rec", "Disease"],
+        ["S_strata", "Strata"],
+        ["I_strata", "Strata"],
+        ["R_strata", "Strata"]
+      ]
+    }
+  },
+  "metadata": {
+    "processed_at": 1682964953,
+    "processed_by": "mit:process-node1",
+    "variable_statements": [
+      {
+        "id": "v0",
+        "variable": {
+          "id": "v0",
+          "name": "VE",
+          "metadata": [
+            {
+              "type": "text_annotation",
+              "value": " Vaccine Effectiveness"
+            },
+            {
+              "type": "text_annotation",
+              "value": " Vaccine Effectiveness"
+            }
+          ],
+          "dkg_groundings": [],
+          "column": [
+            {
+              "id": "9-2",
+              "name": "new_persons_vaccinated",
+              "dataset": {
+                "id": "9",
+                "name": "usa-vaccinations.csv",
+                "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+              }
+            },
+            {
+              "id": "9-3",
+              "name": "cumulative_persons_vaccinated",
+              "dataset": {
+                "id": "9",
+                "name": "usa-vaccinations.csv",
+                "metadata": "https://github.com/DARPA-ASKEM/program-milestones/blob/main/6-month-milestone/evaluation/scenario_3/ta_1/google-health-data/usa-vaccinations.csv"
+              }
+            }
+          ],
+          "paper": {
+            "id": "COVID-19 Vaccine Effectiveness by Product and Timing in New York State",
+            "file_directory": "https://www.medrxiv.org/content/10.1101/2021.10.08.21264595v1",
+            "doi": "10.1101/2021.10.08.21264595"
+          },
+          "equations": []
+        },
+        "metadata": [],
+        "provenance": {
+          "method": "MIT annotation",
+          "description": "text, dataset, formula annotation (chunwei@mit.edu)"
+        }
+      }
+    ]
+  }
+}

--- a/petrinet/petrinet_schema.json
+++ b/petrinet/petrinet_schema.json
@@ -11,7 +11,7 @@
     },
     "schema_name": {
       "type": "string"
-    },    
+    },
     "description": {
       "type": "string"
     },
@@ -32,10 +32,7 @@
         }
       },
       "additionalProperties": false,
-      "required": [
-        "states",
-        "transitions"
-      ]
+      "required": ["states", "transitions"]
     },
     "semantics": {
       "type": "object",
@@ -47,6 +44,14 @@
         "typing": {
           "description": "(Optional) Information for aligning models for stratification",
           "$ref": "#/$defs/typingSemantics"
+        },
+        "span": {
+          "type": "array",
+          "description": "(Optional) Legs of a span, each of which are a full ASKEM Petri Net",
+          "items": {
+            "type": "object",
+            "$ref": "#/$defs/typingSemantics"
+          }
         }
       }
     },
@@ -77,10 +82,8 @@
             "$ref": "#/$defs/unit"
           }
         },
-        "required": [
-          "id"
-        ]
-      }      
+        "required": ["id"]
+      }
     },
     "transitions": {
       "type": "array",
@@ -109,11 +112,7 @@
             "$ref": "#/$defs/properties"
           }
         },
-        "required": [
-          "id",
-          "input",
-          "output"
-        ]
+        "required": ["id", "input", "output"]
       }
     },
     "observables": {
@@ -146,9 +145,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id"
-        ]
+        "required": ["id"]
       }
     },
     "properties": {
@@ -164,9 +161,7 @@
           "$ref": "#/$defs/grounding"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": true
     },
     "distribution": {
@@ -179,10 +174,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "type",
-        "parameters"
-      ],
+      "required": ["type", "parameters"],
       "additionalProperties": true
     },
     "unit": {
@@ -207,9 +199,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "identifiers"
-      ],
+      "required": ["identifiers"],
       "additionalProperties": false
     },
     "provenance": {
@@ -222,10 +212,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "value"
-      ],
+      "required": ["type", "value"],
       "additionalProperties": false
     },
     "metadatum": {
@@ -238,10 +225,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "type",
-        "value"
-      ],
+      "required": ["type", "value"],
       "additionalProperties": false
     },
     "dataset": {
@@ -260,9 +244,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "additionalProperties": false
     },
     "paper": {
@@ -287,33 +269,18 @@
           "type": "object"
         }
       },
-      "required": [
-        "id",
-        "doi"
-      ],
+      "required": ["id", "doi"],
       "additionalProperties": false
     },
     "typingSemantics": {
       "type": "object",
       "properties": {
-        "type_system": {
+        "system": {
           "type": "object",
           "description": "A Petri net representing the 'type system' that is necessary to align states and transitions across different models during stratification.",
-          "properties": {
-            "states": {
-              "$ref": "#/$defs/states"
-            },
-            "transitions": {
-              "$ref": "#/$defs/transitions"
-            }
-          },
-          "additionalProperties": false,
-          "required": [
-            "states",
-            "transitions"
-          ]
+          "$ref": "#"
         },
-        "type_map": {
+        "map": {
           "type": "array",
           "description": "A map between the (state and transition) nodes of the model and the (state and transition) nodes of the type system",
           "items": {
@@ -323,7 +290,8 @@
             }
           }
         }
-      }
+      },
+      "required": ["system", "map"]
     },
     "odeSemantics": {
       "type": "object",
@@ -389,9 +357,7 @@
                 "$ref": "#/$defs/unit"
               }
             },
-            "required": [
-              "id"
-            ]
+            "required": ["id"]
           }
         },
         "time": {
@@ -404,19 +370,12 @@
               "$ref": "#/$defs/unit"
             }
           },
-          "required": [
-            "id"
-          ]
+          "required": ["id"]
         }
       },
       "required": []
     }
   },
   "additionalProperties": true,
-  "required": [
-    "name",
-    "description",
-    "schema",
-    "model"
-  ]
+  "required": ["name", "description", "schema", "model"]
 }

--- a/petrinet/scripts/julia/.gitignore
+++ b/petrinet/scripts/julia/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/petrinet/scripts/julia/ASKEMPetriNets.jl
+++ b/petrinet/scripts/julia/ASKEMPetriNets.jl
@@ -3,22 +3,24 @@ module ASKEMPetriNets
 export AbstractASKEMPetriNet, ASKEMPetriNet, TypedASKEMPetriNet, StratifiedASKEMPetriNet, model, typed_model, update!
 
 using AlgebraicPetri
+using AlgebraicPetri: PropertyLabelledPetriNetUntyped
 using Catlab
 using Catlab.CategoricalAlgebra.CSets: ACSetLimit
 
 import JSON
 
-const JSONPetri = PropertyLabelledPetriNet{Dict{String,Any}}
+const StringDict = Dict{String,Any}
+const JSONPetri = PropertyLabelledPetriNet{StringDict}
 
 abstract type AbstractASKEMPetriNet end
 
 struct ASKEMPetriNet <: AbstractASKEMPetriNet
-  model::JSONPetri
+  model::AbstractPetriNet
   json::AbstractDict
 end
 
 struct TypedASKEMPetriNet <: AbstractASKEMPetriNet
-  model::ACSetTransformation{JSONPetri}
+  model::ACSetTransformation
   json::AbstractDict
 end
 
@@ -32,6 +34,22 @@ model(askem_net::TypedASKEMPetriNet) = dom(askem_net.model)
 model(askem_net::StratifiedASKEMPetriNet) = apex(askem_net.model)
 typed_model(askem_net::TypedASKEMPetriNet) = askem_net.model
 typed_model(askem_net::StratifiedASKEMPetriNet) = first(legs(askem_net.model.cone)) ⋅ first(legs(askem_net.model.diagram))
+
+flat_symbol(sym::Symbol; sep="_")::Symbol = sym
+flat_symbol(sym::Tuple; sep="_")::Symbol = mapreduce(x -> isa(x, Tuple) ? flat_symbol(x, sep) : x, (x, y) -> Symbol(x, sep, y), sym)
+flat_string(args...) = String(flat_symbol(args...))
+
+function type_map(typed_petri::ACSetTransformation)
+  comps, pn, type_system = typed_petri.components, typed_petri.dom, typed_petri.codom
+  vcat(
+    map(enumerate(force(comps.S).func)) do (state, type)
+      [flat_string(pn[state, :sname]), flat_string(type_system[type, :sname])]
+    end,
+    map(enumerate(force(comps.T).func)) do (transition, type)
+      [flat_string(pn[transition, :tname]), flat_string(type_system[type, :tname])]
+    end
+  )
+end
            
 function extract_petri(model::AbstractDict)
   state_props = Dict(Symbol(s["id"]) => s for s in model["states"])
@@ -81,9 +99,41 @@ end
 
 TypedASKEMPetriNet(file::AbstractString) = TypedASKEMPetriNet(ASKEMPetriNet(file))
 
+function StratifiedASKEMPetriNet(file::AbstractString)
+  # TODO: implement ingestion of stratified ASKEM petri net models
+  error("Ingestion of stratified ASKEM JSON file not implemented yet")
+end
+
 function StratifiedASKEMPetriNet(pb::ACSetLimit, ps::AbstractVector{TypedASKEMPetriNet})
-  # TODO: Construct JSON from the pullback and original TypedASKEMPetriNets
-  json = Dict()
+  pn = apex(pb)
+  json = StringDict(
+    "name"=>"",
+    "description"=>"",
+    "model_version"=>"0.1",
+    "schema"=>"https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json"
+  )
+  json["model"] = StringDict(
+    "states"=>map(parts(pn, :S)) do s
+      StringDict("id"=>flat_string(pn[s, :sname]))
+    end,
+    "transitions"=>map(parts(pn, :T)) do t
+      StringDict(
+        "id"=>flat_string(pn[t, :tname]),
+        "input"=>flat_string.(pn[pn[incident(pn, t, :it), :is], :sname]),
+        "output"=>flat_string.(pn[pn[incident(pn, t, :ot), :os], :sname]),
+      )
+    end
+  )
+  json["semantics"] = StringDict()
+  json["semantics"]["typing"] = StringDict(
+    "system"=>first(ps).json["semantics"]["typing"]["system"],
+    "map"=>type_map(first(legs(pb.cone)) ⋅ first(legs(pb.diagram)))
+  )
+  json["semantics"]["span"] = map(enumerate(legs(pb))) do (i, leg)
+    json["name"] *= string(json["name"] == "" ? "" : " + ", ps[i].json["name"])
+    json["description"] *= string(json["description"] == "" ? "" : " ; ", ps[i].json["description"])
+    return StringDict("system"=>ps[i].json, "map"=>type_map(leg))
+  end
   StratifiedASKEMPetriNet(pb, json)
 end
 
@@ -117,20 +167,19 @@ end
 function update!(askem_net::TypedASKEMPetriNet)
   update!(askem_net.model.dom)
   update!(askem_net.model.codom)
-  comps, pn, type_system = askem_net.model.components, askem_net.model.dom, askem_net.model.codom
-  askem_net.json["semantics"]["typing"]["map"] = vcat(
-    map(enumerate(comps.S.func)) do (state, type)
-      [String(pn[state, :sname]), String(type_system[type, :sname])]
-    end,
-    map(enumerate(comps.T.func)) do (transition, type)
-      [String(pn[transition, :tname]), String(type_system[type, :tname])]
-    end
-  )
+  askem_net.json["semantics"]["typing"]["map"] = type_map(askem_net.model)
   askem_net
 end
 
 function update!(askem_net::StratifiedASKEMPetriNet)
-  # TODO: Write update function for stratified ASKEMPetriNets
+  # TODO: Update! for models with tuples of attributes
+  # update!(TypedASKEMPetriNet(typed_model(askem_net), askem_net.json))
+  span_legs = legs(askem_net.model)
+  map(enumerate(legs(askem_net.model.diagram))) do (i, leg)
+    leg_json = askem_net.json["semantics"]["span"][i]
+    update!(TypedASKEMPetriNet(leg, leg_json["system"]))
+    leg_json["map"] = type_map(span_legs[i])
+  end
   askem_net
 end
 

--- a/petrinet/scripts/julia/ASKEMPetriNets.jl
+++ b/petrinet/scripts/julia/ASKEMPetriNets.jl
@@ -100,14 +100,12 @@ ASKEMPetriNet(typed_petri::TypedASKEMPetriNet) = ASKEMPetriNet(typed_petri.model
 
 ASKEMPetriNet(strat_petri::StratifiedASKEMPetriNet) = ASKEMPetriNet(apex(strat_petri.model), strat_petri.json)
 
-#=
 TypedASKEMPetriNet(petri::ASKEMPetriNet) = begin
   dom = petri.model
   typing = petri.json["semantics"]["typing"]
   tpn = extract_typing(dom,typing)
   TypedASKEMPetriNet(tpn, petri.json)
 end
-=#
 
 TypedASKEMPetriNet(json::AbstractDict) = begin
   dom = extract_petri(json["model"])
@@ -189,7 +187,7 @@ end
 function form_typing_semantics(tpn::ACSetTransformation)
   semantics = StringDict()
   semantics["system"] = form_amr(codom(tpn))
-  semantics["map"] = form_map_semantics(tpn)
+  semantics["map"] = type_map(tpn)
   return semantics
 end
 
@@ -205,8 +203,9 @@ end
 # Functions to form AMR dictionary of AbstractASKEMPetriNets *
 #*************************************************************
 
-function form_amr(pn::PropertyLabelledPetriNet; 
-  name="A Petri Net", 
+# function form_amr(pn::PropertyLabelledPetriNet; 
+function form_amr(pn::AbstractPetriNet; 
+    name="A Petri Net", 
   schema="https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json", 
   description="A Petri net in AMR format",
   version="0.1",

--- a/petrinet/scripts/julia/ASKEMPetriNets.jl
+++ b/petrinet/scripts/julia/ASKEMPetriNets.jl
@@ -38,19 +38,11 @@ typed_model(askem_net::StratifiedASKEMPetriNet) = first(legs(askem_net.model.con
 flat_symbol(sym::Symbol; sep="_")::Symbol = sym
 flat_symbol(sym::Tuple; sep="_")::Symbol = mapreduce(x -> isa(x, Tuple) ? flat_symbol(x, sep) : x, (x, y) -> Symbol(x, sep, y), sym)
 flat_string(args...) = String(flat_symbol(args...))
-
-function type_map(typed_petri::ACSetTransformation)
-  comps, pn, type_system = typed_petri.components, typed_petri.dom, typed_petri.codom
-  vcat(
-    map(enumerate(force(comps.S).func)) do (state, type)
-      [flat_string(pn[state, :sname]), flat_string(type_system[type, :sname])]
-    end,
-    map(enumerate(force(comps.T).func)) do (transition, type)
-      [flat_string(pn[transition, :tname]), flat_string(type_system[type, :tname])]
-    end
-  )
-end
            
+#**********************************************************
+# Functions to extract Petri net structures from AMR JSON *
+#**********************************************************
+
 function extract_petri(model::AbstractDict)
   state_props = Dict(Symbol(s["id"]) => s for s in model["states"])
   states = [Symbol(s["id"]) for s in model["states"]]
@@ -60,49 +52,87 @@ function extract_petri(model::AbstractDict)
   JSONPetri(LabelledPetriNet(states, transitions...), state_props, transition_props)
 end
 
-function ASKEMPetriNet(file::AbstractString)
-  json = JSON.parsefile(file)
-  ASKEMPetriNet(extract_petri(json["model"]), json)
-end
-
-ASKEMPetriNet(typed_petri::TypedASKEMPetriNet) = ASKEMPetriNet(typed_petri.model.dom, typed_petri.json)
-
-function TypedASKEMPetriNet(petri::ASKEMPetriNet)
-  typing = petri.json["semantics"]["typing"]
-  type_system = extract_petri(typing["system"]["model"])
-  type_map = Dict(Symbol(k)=>Symbol(v) for (k,v) in typing["map"])
-  S = map(snames(petri.model)) do state
+function extract_typing(dom::PropertyLabelledPetriNet,typing_dict::AbstractDict)
+  type_system = extract_petri(typing_dict["system"]["model"])
+  type_map = Dict(Symbol(k)=>Symbol(v) for (k,v) in typing_dict["map"])
+  S = map(snames(dom)) do state
     only(incident(type_system, type_map[state], :sname))
   end
-  T = map(tnames(petri.model)) do transition
+  T = map(tnames(dom)) do transition
     only(incident(type_system, type_map[transition], :tname))
   end
   type_its = Dict{Int,Vector{Int}}()
-  I = map(parts(petri.model, :I)) do i
-    type_transition = T[petri.model[i, :it]]
+  I = map(parts(dom, :I)) do i
+    type_transition = T[dom[i, :it]]
     if !haskey(type_its, type_transition) || isempty(type_its[type_transition])
       type_its[type_transition] = copy(incident(type_system, type_transition, :it))
     end
     popfirst!(type_its[type_transition])
   end
   type_ots = Dict{Int,Vector{Int}}()
-  O = map(parts(petri.model, :O)) do o
-    type_transition = T[petri.model[o, :ot]]
+  O = map(parts(dom, :O)) do o
+    type_transition = T[dom[o, :ot]]
     if !haskey(type_ots, type_transition) || isempty(type_ots[type_transition])
       type_ots[type_transition] = copy(incident(type_system, type_transition, :ot))
     end
     popfirst!(type_ots[type_transition])
   end
-
-  TypedASKEMPetriNet(LooseACSetTransformation((S=S, T=T, I=I, O=O), (Name=x->nothing, Prop=x->nothing), petri.model, type_system), petri.json)
+  LooseACSetTransformation((S=S, T=T, I=I, O=O), (Name=x->nothing, Prop=x->nothing), dom, type_system)
 end
 
-TypedASKEMPetriNet(file::AbstractString) = TypedASKEMPetriNet(ASKEMPetriNet(file))
-
-function StratifiedASKEMPetriNet(file::AbstractString)
-  # TODO: implement ingestion of stratified ASKEM petri net models
-  error("Ingestion of stratified ASKEM JSON file not implemented yet")
+function extract_span(apex::PropertyLabelledPetriNet,span_dict::Vector{Any}) # Dict{String,Any}})
+  span = Vector{ACSetTransformation}()
+  for leg in span_dict
+    push!(span,extract_typing(apex,leg))
+  end
+  return span
 end
+
+#**************************************************************************
+# Constructors for AbstractASKEMPetriNets from file or base ASKEMPetriNet *
+#**************************************************************************
+
+ASKEMPetriNet(json::AbstractDict) = ASKEMPetriNet(extract_petri(json["model"]), json)
+
+ASKEMPetriNet(file::AbstractString) = ASKEMPetriNet(JSON.parsefile(file))
+
+ASKEMPetriNet(typed_petri::TypedASKEMPetriNet) = ASKEMPetriNet(typed_petri.model.dom, typed_petri.json)
+
+ASKEMPetriNet(strat_petri::StratifiedASKEMPetriNet) = ASKEMPetriNet(apex(strat_petri.model), strat_petri.json)
+
+#=
+TypedASKEMPetriNet(petri::ASKEMPetriNet) = begin
+  dom = petri.model
+  typing = petri.json["semantics"]["typing"]
+  tpn = extract_typing(dom,typing)
+  TypedASKEMPetriNet(tpn, petri.json)
+end
+=#
+
+TypedASKEMPetriNet(json::AbstractDict) = begin
+  dom = extract_petri(json["model"])
+  typing = json["semantics"]["typing"]
+  tpn = extract_typing(dom, typing)
+  TypedASKEMPetriNet(tpn, json)
+end
+
+TypedASKEMPetriNet(file::AbstractString) = TypedASKEMPetriNet(JSON.parsefile(file))
+
+#=
+StratifiedASKEMPetriNet(petri::ASKEMPetriNet) = begin
+  spn = petri.json["semantics"]["span"]
+  lgs = [TypedASKEMPetriNet(lg["system"]).model for lg in spn]
+  StratifiedASKEMPetriNet(pullback(lgs; product_attrs=true), petri.json)
+end
+=#
+
+StratifiedASKEMPetriNet(json::AbstractDict) = begin
+  spn = json["semantics"]["span"]
+  lgs = [TypedASKEMPetriNet(lg["system"]).model for lg in spn]
+  StratifiedASKEMPetriNet(pullback(lgs; product_attrs=true), json)
+end
+
+StratifiedASKEMPetriNet(file::AbstractString) = StratifiedASKEMPetriNet(JSON.parsefile(file))
 
 function StratifiedASKEMPetriNet(pb::ACSetLimit, ps::AbstractVector{TypedASKEMPetriNet})
   pn = apex(pb)
@@ -139,6 +169,91 @@ end
 
 StratifiedASKEMPetriNet(p1::TypedASKEMPetriNet, p2::TypedASKEMPetriNet) = StratifiedASKEMPetriNet(pullback(p1.model, p2.model; product_attrs=true), [p1, p2])
 StratifiedASKEMPetriNet(ps::AbstractVector{TypedASKEMPetriNet}) = StratifiedASKEMPetriNet(pullback(ps; product_attrs=true), ps)
+
+#**********************************************************************
+# Functions to form AMR semantic components of AbstractASKEMPetriNets *
+#**********************************************************************
+
+function type_map(typed_petri::ACSetTransformation)
+  comps, pn, type_system = typed_petri.components, typed_petri.dom, typed_petri.codom
+  vcat(
+    map(enumerate(force(comps.S).func)) do (state, type)
+      [flat_string(pn[state, :sname]), flat_string(type_system[type, :sname])]
+    end,
+    map(enumerate(force(comps.T).func)) do (transition, type)
+      [flat_string(pn[transition, :tname]), flat_string(type_system[type, :tname])]
+    end
+  )
+end
+
+function form_typing_semantics(tpn::ACSetTransformation)
+  semantics = StringDict()
+  semantics["system"] = form_amr(codom(tpn))
+  semantics["map"] = form_map_semantics(tpn)
+  return semantics
+end
+
+function form_span_semantics(span::Vector{ACSetTransformation})
+  semantics = Vector{StringDict}()
+  for leg in span
+    push!(semantics,form_typing_semantics(leg))
+  end
+  return semantics
+end
+
+#*************************************************************
+# Functions to form AMR dictionary of AbstractASKEMPetriNets *
+#*************************************************************
+
+function form_amr(pn::PropertyLabelledPetriNet; 
+  name="A Petri Net", 
+  schema="https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json", 
+  description="A Petri net in AMR format",
+  version="0.1",
+  semantics=StringDict(),
+  meta=StringDict())
+
+  amr = StringDict()
+  amr["name"] = name
+  amr["schema"] = schema
+  amr["description"] = description
+  amr["model_version"] = version
+  amr["semantics"] = semantics
+  amr["metadata"] = meta
+
+  amr["model"] = StringDict(
+    "states"=>map(parts(pn, :S)) do s
+      StringDict("id"=>flat_string(pn[s, :sname]))
+    end,
+    "transitions"=>map(parts(pn, :T)) do t
+      StringDict(
+        "id"=>flat_string(pn[t, :tname]),
+        "input"=>flat_string.(pn[pn[incident(pn, t, :it), :is], :sname]),
+        "output"=>flat_string.(pn[pn[incident(pn, t, :ot), :os], :sname]),
+      )
+    end
+  )
+  return amr
+end
+
+function form_amr(tpn::ACSetTransformation)
+  amr = form_amr(dom(tpn),name="A Typed Petri Net", description="A typed Petri net in AMR format")
+  amr["semantics"] = StringDict()
+  amr["semantics"]["typing"] = form_typing_semantics(tpn)
+  return amr
+end
+
+function form_amr(pb::ACSetLimit)
+  amr = form_amr(pn,name="A Stratified Petri Net", description="A stratified Petri net in AMR format")  
+  amr["semantics"] = StringDict()
+  amr["semantics"]["typing"] = form_typing_semantics(first(legs(pb.cone)) ⋅ first(legs(pb.diagram)))
+  amr["semantics"]["span"] = form_span_semantics(legs(pb.diagram))
+  return amr
+end
+
+#********************************************
+# Functions to update AbstractASKEMPetriNet *
+#********************************************
 
 function update!(pn::PropertyLabelledPetriNet)
   map(parts(pn, :S)) do s

--- a/petrinet/scripts/julia/test.jl
+++ b/petrinet/scripts/julia/test.jl
@@ -3,13 +3,14 @@
 
 include("./ASKEMPetriNets.jl")
 using AlgebraicPetri
-using Catlab.CategoricalAlgebra, Catlab.Graphics
+using Catlab
 using JSON
 
 # Load a model
 askemnet = ASKEMPetriNets.to_petri("../../examples/sir.json")
 
 askemnet.model |> to_graphviz
+ASKEMPetriNets.model(askemnet) |> to_graphviz
 
 # Do modifications to the model
 askemnet.model[1, :sname] = :M
@@ -23,7 +24,8 @@ JSON.print(askemnet, 2)
 
 typed_askemnet = ASKEMPetriNets.to_typed_petri("../../examples/sir_typed.json")
 
-typed_askemnet.model |> to_graphviz
+ASKEMPetriNets.model(typed_askemnet) |> to_graphviz
+ASKEMPetriNets.typed_model(typed_askemnet) |> to_graphviz
 
 @assert is_natural(typed_askemnet.model)
 
@@ -36,3 +38,11 @@ ASKEMPetriNets.update!(typed_askemnet)
 
 # Print new JSON
 JSON.print(typed_askemnet, 2)
+
+sir = ASKEMPetriNets.to_typed_petri("../../examples/sir_typed.json")
+flux = ASKEMPetriNets.to_typed_petri("../../examples/flux_typed.json")
+
+sir_flux = ASKEMPetriNets.to_stratified_petri(sir, flux)
+
+ASKEMPetriNets.model(sir_flux) |> to_graphviz
+ASKEMPetriNets.typed_model(sir_flux) |> to_graphviz

--- a/petrinet/scripts/julia/test.jl
+++ b/petrinet/scripts/julia/test.jl
@@ -2,30 +2,31 @@
 #########
 
 include("./ASKEMPetriNets.jl")
+using .ASKEMPetriNets
+
 using AlgebraicPetri
 using Catlab
 using JSON
 
 # Load a model
-askemnet = ASKEMPetriNets.to_petri("../../examples/sir.json")
+askemnet = ASKEMPetriNet("../../examples/sir.json")
 
-askemnet.model |> to_graphviz
-ASKEMPetriNets.model(askemnet) |> to_graphviz
+model(askemnet) |> to_graphviz
 
 # Do modifications to the model
 askemnet.model[1, :sname] = :M
 askemnet.model[1, :tname] = :infect
 
 # Update the properties and JSON with new modifications to structure
-ASKEMPetriNets.update!(askemnet)
+update!(askemnet)
 
 # Print new JSON
 JSON.print(askemnet, 2)
 
-typed_askemnet = ASKEMPetriNets.to_typed_petri("../../examples/sir_typed.json")
+typed_askemnet = TypedASKEMPetriNet("../../examples/sir_typed.json")
 
-ASKEMPetriNets.model(typed_askemnet) |> to_graphviz
-ASKEMPetriNets.typed_model(typed_askemnet) |> to_graphviz
+model(typed_askemnet) |> to_graphviz
+typed_model(typed_askemnet) |> to_graphviz
 
 @assert is_natural(typed_askemnet.model)
 
@@ -34,15 +35,17 @@ typed_askemnet.model.dom[1, :tname] = :infect
 typed_askemnet.model.codom[1, :sname] = :People
 
 # Update the properties and JSON with new modifications to structure
-ASKEMPetriNets.update!(typed_askemnet)
+update!(typed_askemnet)
 
 # Print new JSON
 JSON.print(typed_askemnet, 2)
 
-sir = ASKEMPetriNets.to_typed_petri("../../examples/sir_typed.json")
-flux = ASKEMPetriNets.to_typed_petri("../../examples/flux_typed.json")
+# Stratification
 
-sir_flux = ASKEMPetriNets.to_stratified_petri(sir, flux)
+sir = TypedASKEMPetriNet("../../examples/sir_typed_aug.json")
+flux = TypedASKEMPetriNet("../../examples/flux_typed_aug.json")
 
-ASKEMPetriNets.model(sir_flux) |> to_graphviz
-ASKEMPetriNets.typed_model(sir_flux) |> to_graphviz
+sir_flux = StratifiedASKEMPetriNet(sir, flux)
+
+model(sir_flux) |> to_graphviz
+typed_model(sir_flux) |> to_graphviz

--- a/petrinet/scripts/julia/test.jl
+++ b/petrinet/scripts/julia/test.jl
@@ -49,3 +49,5 @@ sir_flux = StratifiedASKEMPetriNet(sir, flux)
 
 model(sir_flux) |> to_graphviz
 typed_model(sir_flux) |> to_graphviz
+
+JSON.print(sir_flux, 2)


### PR DESCRIPTION
This PR is superseding #27 with a much simpler and streamlined API and takes a more Catlab/AlgebraicJulia approach to the internal mechanisms while maintaining the same integration point of the ASKEM Model-Representation JSON schemas.

So far this has the ability to calculate the stratification of ingested AMR represented models. All that's left is adding in the JSON updating/exporting of stratified models.