### PR TITLE
Update uniform distribution name

### DIFF
--- a/petrinet/examples/sir.json
+++ b/petrinet/examples/sir.json
@@ -122,7 +122,7 @@
           },
           "value": 2.7e-7,
           "distribution": {
-            "type": "StandardUniform1",
+            "type": "Uniform1",
             "parameters": {
               "minimum": 2.6e-7,
               "maximum": 2.8e-7
@@ -144,7 +144,7 @@
           },
           "value": 0.14,
           "distribution": {
-            "type": "StandardUniform1",
+            "type": "Uniform1",
             "parameters": {
               "minimum": 0.1,
               "maximum": 0.18

--- a/petrinet/examples/sir_typed.json
+++ b/petrinet/examples/sir_typed.json
@@ -106,7 +106,7 @@
           "description": "infection rate",
           "value": 0.027,
           "distribution": {
-            "type": "StandardUniform1",
+            "type": "Uniform1",
             "parameters": {
               "minimum": 0.026,
               "maximum": 0.028
@@ -124,7 +124,7 @@
           },
           "value": 0.14,
           "distribution": {
-            "type": "StandardUniform1",
+            "type": "Uniform1",
             "parameters": {
               "minimum": 0.1,
               "maximum": 0.18


### PR DESCRIPTION
This PR fixes a mistake in the distribution class used in example models: these should be `Uniform1` rather than `StandardUniform1` per ProbOnto's definition of distributions. Fixes #48.