### PR TITLE
Algebraic Data Type version of AMR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
+MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"

--- a/Project.toml
+++ b/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"

--- a/src/julia/amr.jl
+++ b/src/julia/amr.jl
@@ -73,11 +73,11 @@ end
 
 function distro_string(d::Distribution)
   @match d begin
-    StandardUniform => "U(0,1)"
+    StandardUniform   => "U(0,1)"
     Uniform(min, max) => "U($min,$max)"
-    StandardNormal => "N(0,1)"
-    Normal(mu, var) => "N($mu,$var)"
-    PointMass(value) => "δ(value)"
+    StandardNormal    => "N(0,1)"
+    Normal(mu, var)   => "N($mu,$var)"
+    PointMass(value)  => "δ(value)"
   end
 end
 
@@ -90,25 +90,25 @@ function amr_to_string(amr)
   @show typeof(amr)
   let ! = amr_to_string
     @match amr begin
-      s::String       => s
-      Math(s)         => !s
-      Presentation(s) => "<mathml> $s </mathml>"
-      u::Unit         => !u.expression
-      d::Distribution => distro_string(d)
-      Rate(t, f)      => "$t::Rate = $(f.expression)"
-      Initial(t, f)      => "$t::Initial = $(f.expression)"
-      Parameter(t, name, desc, units, value, distr)      => "\n# $name -- $desc\n$t::Parameter{$(!units)} = $value ~ $(!distr)\n"
-      Observable(id, name, states, f) => "# $name\n$id::Observable = $(f.expression)($states)\n"
-      Time(id, u) => "$id::Time{$(!u)}\n"
-      Header(name, s, d, sn, mv) => "\"\"\"\nASKE Model Representation: $name@v$mv :: $sn \n   $s\n\n$d\n\"\"\""
-      m::ACSetSpec => "Model = begin\n$(padlines(ADTs.to_string(m),2))\nend"
-      ODEList(l) => "ODE Equations: begin\n" * padlines(join(map(!, l), "\n")) * "\nend"
-      ODERecord(rates, initials, parameters, time) => join(vcat(["ODE Record: begin\n"], !rates , !initials, !parameters, [!time, "end"]), "\n")
-      vs::Vector{Pair} => map(vs) do v; "$(v[1]) => $(v[2])," end |> x-> join(x, "\n") 
-      vs::Vector{Semantic} => join(map(!, vs), "\n\n")
-      xs::Vector => map(!, xs)
-      Typing(system, map) => "Typing: begin\n$(padlines(!system, 2))\nTypeMap = [\n$(padlines(!map, 2))]\nend"
-      ASKEModel(h, m, s) => "$(!h)\n$(!m)\n\n$(!s)"
+      s::String                        => s
+      Math(s)                          => !s
+      Presentation(s)                  => "<mathml> $s </mathml>"
+      u::Unit                          => !u.expression
+      d::Distribution                  => distro_string(d)
+      Time(id, u)                      => "$id::Time{$(!u)}\n"
+      Rate(t, f)                       => "$t::Rate = $(f.expression)"
+      Initial(t, f)                    => "$t::Initial = $(f.expression)"
+      Observable(id, n, states, f)     => "# $n\n$id::Observable = $(f.expression)($states)\n"
+      Header(name, s, d, sn, mv)       => "\"\"\"\nASKE Model Representation: $name$mv :: $sn \n   $s\n\n$d\n\"\"\""
+      Parameter(t, n, d, u, v, dist)   => "\n# $n-- $d\n$t::Parameter{$(!u)} = $v ~ $(!dist)\n"
+      m::ACSetSpec                     => "Model = begin\n$(padlines(ADTs.to_string(m),2))\nend"
+      ODEList(l)                       => "ODE Equations: begin\n" * padlines(join(map(!, l), "\n")) * "\nend"
+      ODERecord(rts, init, para, time) => join(vcat(["ODE Record: begin\n"], !rts , !init, !para, [!time, "end"]), "\n")
+      vs::Vector{Pair}                 => map(vs) do v; "$(v[1]) => $(v[2])," end |> x-> join(x, "\n") 
+      vs::Vector{Semantic}             => join(map(!, vs), "\n\n")
+      xs::Vector                       => map(!, xs)
+      Typing(system, map)              => "Typing: begin\n$(padlines(!system, 2))\nTypeMap = [\n$(padlines(!map, 2))]\nend"
+      ASKEModel(h, m, s)               => "$(!h)\n$(!m)\n\n$(!s)"
     end
   end
 end

--- a/src/julia/amr.jl
+++ b/src/julia/amr.jl
@@ -9,8 +9,7 @@ using ACSets.ACSetInterface
   Presentation(String)
 end
 
-@as_record struct ExpressionValue{T}
-  target::Symbol
+@as_record struct ExpressionFormula{T}
   expression::T
   expression_mathml::MathML
 end
@@ -28,38 +27,23 @@ end
   PointMass(value)
 end
 
-# @as_record struct Parameter
-#   id::Symbol
-#   name::String
-#   description::String
-#   units::Unit
-#   value::Float64
-#   distribution::Distribution
-# end
-
 @as_record struct Observable{T}
   id::Symbol
   name::String
   states::Vector{Symbol}
-  expression::T
-  expression_mathml::MathML
+  f::ExpressionFormula
 end
 
-# @as_record struct Time
-#   id::Symbol
-#   units::Unit
-# end
-
 @data Expression begin
-  Rate(ExpressionValue)
-  Initial(ExpressionValue)
+  Rate(target::Symbol, f::ExpressionFormula)
+  Initial(target::Symbol, f::ExpressionFormula)
   Parameter(id::Symbol, name::String, description::String, units::Unit, value::Float64, distribution::Distribution)
   Time(id::Symbol, units::Unit)
 end
 
 @data Semantic begin
-  ODE(rates::Vector{ExpressionValue}, initials::Vector{ExpressionValue}, parameters::Vector{Parameter}, time::Time)
   ODEList(statements::Vector{Expression})
+  ODERecord(rates::Vector{Rate}, initials::Vector{Initial}, parameters::Vector{Parameter}, time::Time)
   # Metadata
   # Typing
   # Stratification
@@ -79,8 +63,42 @@ end
   semantics::Vector{Semantic}
 end
 
+function distro_string(d::Distribution)
+  @match d begin
+    StandardUniform => "U(0,1)"
+    Uniform(min, max) => "U($min,$max)"
+    StandardNormal => "N(0,1)"
+    Normal(mu, var) => "N($mu,$var)"
+    PointMass(value) => "δ(value)"
+  end
+end
+
+function amr_to_string(amr)
+  let ! = amr_to_string
+    @match amr begin
+      s::String       => s
+      Math(s)         => !s
+      Presentation(s) => "<mathml> $s </mathml>"
+      u::Unit         => !u.expression
+      d::Distribution => distro_string(d)
+      Rate(t, f)      => "$t::Rate = $(f.expression)"
+      Initial(t, f)      => "$t::Initial = $(f.expression)"
+      Parameter(t, name, desc, units, value, distr)      => "\n# $name -- $desc\n$t::Parameter{$(!units)} = $value ~ $(!distr)\n"
+      Observable(id, name, states, f) => "# $name\n$id::Observable = $(f.expression)($states)\n"
+      Time(id, u) => "$id::Time{$(!u)}\n"
+      Header(name, s, d, sn, mv) => "\"\"\"\nASKE Model Representation: $name@v$mv :: $sn \n   $s\n\n$d\n\"\"\""
+      m::ACSetSpec => "Model = quote\n$(ADTs.to_string(m))\nend"
+      vs::Vector{Semantic} => join(map(!, vs), "\n")
+      xs::Vector => map(!, xs)
+      ODEList(l) => "ODE Equations: begin\n" * join(map(!, l), "\n") * "\nend"
+      ODERecord(rates, initials, parameters, time) => join(vcat(["ODE Record: begin\n"], !rates , !initials, !parameters, [!time, "end"]), "\n")
+      ASKEModel(h, m, s) => "$(!h)\n$(!m)\n\n$(!s)"
+    end
+  end
+end
+
 nomath = Math("")
-header = Header("SIR", "amr-schemas:petri_schema.json", "The SIR Model of disease", "petrinet", "v0.2")
+header = Header("SIR", "amr-schemas:petri_schema.json", "The SIR Model of disease", "petrinet", "0.2")
 model = acsetspec(:(LabelledPetriNet{Symbol}), quote
   S(label=:S)
   S(label=:I)
@@ -98,13 +116,12 @@ model = acsetspec(:(LabelledPetriNet{Symbol}), quote
   O(os=:R, it=:rec)
 end) 
 
+ode = ODERecord([Rate(:inf, ExpressionFormula( "S*I*β", nomath)),
+           Rate(:rec, ExpressionFormula("I*γ", nomath))],
 
-ode = ODE([ExpressionValue(:inf, "S*I*β", nomath),
-           ExpressionValue(:rec, "I*γ", nomath)],
-
-          [ExpressionValue(:S, "S₀", nomath),
-           ExpressionValue(:I, "I₀", nomath),
-           ExpressionValue(:R, "R₀", nomath),],
+          [Initial(:S, ExpressionFormula("S₀", nomath)),
+           Initial(:I, ExpressionFormula("I₀", nomath)),
+           Initial(:R, ExpressionFormula("R₀", nomath)),],
 
           [Parameter(:β, "β", "the beta parameter", Unit("1/(persons^2*day)", nomath), 1e-2, Uniform(1e-3, 2e-2)),
           Parameter(:γ, "γ", "the gama parameter", Unit("1/(persons*day)", nomath), 3, Uniform(1, 2e+2)),
@@ -115,11 +132,36 @@ ode = ODE([ExpressionValue(:inf, "S*I*β", nomath),
           ],
           Time(:t, Unit("day", nomath)))
 
-amr = ASKEModel(header,
+odelist = ODEList([
+  Time(:t, Unit("day", nomath)),
+  Parameter(:β, "β", "the beta parameter", Unit("1/(persons^2*day)", nomath), 1e-2, Uniform(1e-3, 2e-2)),
+  Rate(:inf, ExpressionFormula("S*I*β", nomath)),
+
+  Parameter(:γ, "γ", "the gama parameter", Unit("1/(persons*day)", nomath), 3, Uniform(1, 2e+2)),
+  Rate(:rec, ExpressionFormula("I*γ", nomath)), 
+
+  Parameter(:S₀, "S₀", "the initial susceptible population", Unit("persons", nomath), 300000000.0, Uniform(1e6, 4e6)),
+  Initial(:S₀, ExpressionFormula("S₀", nomath)),
+
+  Parameter(:I₀, "I₀", "the initial infected population", Unit("persons", nomath), 1.0, Uniform(1, 1)),
+  Initial(:I₀, ExpressionFormula("I₀", nomath)),
+
+  Parameter(:R₀, "R₀", "the initial recovered population", Unit("persons", nomath), 0.0, Uniform(0, 4)),
+  Initial(:R₀, ExpressionFormula("R₀", nomath)), 
+
+  ])
+
+amr₁ = ASKEModel(header,
   model,
   [ode]
 )
 
-println(to_string(amr.model))
-println(amr.semantics[1])
-end
+amr₂ = ASKEModel(header,
+  model,
+  [odelist]
+)
+
+println()
+println(amr_to_string(amr₁))
+println(amr_to_string(amr₂))
+end # module end

--- a/src/julia/amr.jl
+++ b/src/julia/amr.jl
@@ -1,0 +1,125 @@
+module AMR
+using MLStyle
+using ACSets
+using ACSets.ADTs
+using ACSets.ACSetInterface
+
+@data MathML begin
+  Math(String)
+  Presentation(String)
+end
+
+@as_record struct ExpressionValue{T}
+  target::Symbol
+  expression::T
+  expression_mathml::MathML
+end
+
+@as_record struct Unit
+  expression::String
+  expression_mathml::MathML
+end
+
+@data Distribution begin
+  StandardUniform
+  Uniform(min, max)
+  StandardNormal
+  Normal(mean, variance)
+  PointMass(value)
+end
+
+# @as_record struct Parameter
+#   id::Symbol
+#   name::String
+#   description::String
+#   units::Unit
+#   value::Float64
+#   distribution::Distribution
+# end
+
+@as_record struct Observable{T}
+  id::Symbol
+  name::String
+  states::Vector{Symbol}
+  expression::T
+  expression_mathml::MathML
+end
+
+# @as_record struct Time
+#   id::Symbol
+#   units::Unit
+# end
+
+@data Expression begin
+  Rate(ExpressionValue)
+  Initial(ExpressionValue)
+  Parameter(id::Symbol, name::String, description::String, units::Unit, value::Float64, distribution::Distribution)
+  Time(id::Symbol, units::Unit)
+end
+
+@data Semantic begin
+  ODE(rates::Vector{ExpressionValue}, initials::Vector{ExpressionValue}, parameters::Vector{Parameter}, time::Time)
+  ODEList(statements::Vector{Expression})
+  # Metadata
+  # Typing
+  # Stratification
+end
+
+@as_record struct Header
+  name::String
+  schema::String
+  description::String
+  schema_name::String
+  model_version::String
+end
+
+@as_record struct ASKEModel
+  header::Header 
+  model::ACSetSpec
+  semantics::Vector{Semantic}
+end
+
+nomath = Math("")
+header = Header("SIR", "amr-schemas:petri_schema.json", "The SIR Model of disease", "petrinet", "v0.2")
+model = acsetspec(:(LabelledPetriNet{Symbol}), quote
+  S(label=:S)
+  S(label=:I)
+  S(label=:R)
+
+  T(label=:inf)
+  T(label=:rec)
+
+  I(is=:S, it=:inf)
+  I(is=:I, it=:inf)
+  I(is=:I, it=:rec)
+
+  O(os=:I, it=:inf)
+  O(os=:I, it=:inf)
+  O(os=:R, it=:rec)
+end) 
+
+
+ode = ODE([ExpressionValue(:inf, "S*I*β", nomath),
+           ExpressionValue(:rec, "I*γ", nomath)],
+
+          [ExpressionValue(:S, "S₀", nomath),
+           ExpressionValue(:I, "I₀", nomath),
+           ExpressionValue(:R, "R₀", nomath),],
+
+          [Parameter(:β, "β", "the beta parameter", Unit("1/(persons^2*day)", nomath), 1e-2, Uniform(1e-3, 2e-2)),
+          Parameter(:γ, "γ", "the gama parameter", Unit("1/(persons*day)", nomath), 3, Uniform(1, 2e+2)),
+
+          Parameter(:S₀, "S₀", "the initial susceptible population", Unit("persons", nomath), 300000000.0, Uniform(1e6, 4e6)),
+          Parameter(:I₀, "I₀", "the initial infected population", Unit("persons", nomath), 1.0, Uniform(1, 1)),
+          Parameter(:R₀, "R₀", "the initial recovered population", Unit("persons", nomath), 0.0, Uniform(0, 4)),
+          ],
+          Time(:t, Unit("day", nomath)))
+
+amr = ASKEModel(header,
+  model,
+  [ode]
+)
+
+println(to_string(amr.model))
+println(amr.semantics[1])
+end

--- a/src/julia/amr.jl
+++ b/src/julia/amr.jl
@@ -1,6 +1,14 @@
 module AMR
-using MLStyle
-using ACSets
+
+export Math, MathML, ExpressionFormula, Unit, Distribution, Observable, Expression,
+ Rate, Initial, Parameter, Time,
+ StandardUniform, Uniform, StandardNormal, Normal, PointMass,
+ Semantic, Header, ODERecord, ODEList, ASKEModel,
+ distro_string, amr_to_string
+
+using Reexport
+@reexport using MLStyle
+@reexport using ACSets
 using ACSets.ADTs
 using ACSets.ACSetInterface
 
@@ -96,72 +104,4 @@ function amr_to_string(amr)
     end
   end
 end
-
-nomath = Math("")
-header = Header("SIR", "amr-schemas:petri_schema.json", "The SIR Model of disease", "petrinet", "0.2")
-model = acsetspec(:(LabelledPetriNet{Symbol}), quote
-  S(label=:S)
-  S(label=:I)
-  S(label=:R)
-
-  T(label=:inf)
-  T(label=:rec)
-
-  I(is=:S, it=:inf)
-  I(is=:I, it=:inf)
-  I(is=:I, it=:rec)
-
-  O(os=:I, it=:inf)
-  O(os=:I, it=:inf)
-  O(os=:R, it=:rec)
-end) 
-
-ode = ODERecord([Rate(:inf, ExpressionFormula( "S*I*β", nomath)),
-           Rate(:rec, ExpressionFormula("I*γ", nomath))],
-
-          [Initial(:S, ExpressionFormula("S₀", nomath)),
-           Initial(:I, ExpressionFormula("I₀", nomath)),
-           Initial(:R, ExpressionFormula("R₀", nomath)),],
-
-          [Parameter(:β, "β", "the beta parameter", Unit("1/(persons^2*day)", nomath), 1e-2, Uniform(1e-3, 2e-2)),
-          Parameter(:γ, "γ", "the gama parameter", Unit("1/(persons*day)", nomath), 3, Uniform(1, 2e+2)),
-
-          Parameter(:S₀, "S₀", "the initial susceptible population", Unit("persons", nomath), 300000000.0, Uniform(1e6, 4e6)),
-          Parameter(:I₀, "I₀", "the initial infected population", Unit("persons", nomath), 1.0, Uniform(1, 1)),
-          Parameter(:R₀, "R₀", "the initial recovered population", Unit("persons", nomath), 0.0, Uniform(0, 4)),
-          ],
-          Time(:t, Unit("day", nomath)))
-
-odelist = ODEList([
-  Time(:t, Unit("day", nomath)),
-  Parameter(:β, "β", "the beta parameter", Unit("1/(persons^2*day)", nomath), 1e-2, Uniform(1e-3, 2e-2)),
-  Rate(:inf, ExpressionFormula("S*I*β", nomath)),
-
-  Parameter(:γ, "γ", "the gama parameter", Unit("1/(persons*day)", nomath), 3, Uniform(1, 2e+2)),
-  Rate(:rec, ExpressionFormula("I*γ", nomath)), 
-
-  Parameter(:S₀, "S₀", "the initial susceptible population", Unit("persons", nomath), 300000000.0, Uniform(1e6, 4e6)),
-  Initial(:S₀, ExpressionFormula("S₀", nomath)),
-
-  Parameter(:I₀, "I₀", "the initial infected population", Unit("persons", nomath), 1.0, Uniform(1, 1)),
-  Initial(:I₀, ExpressionFormula("I₀", nomath)),
-
-  Parameter(:R₀, "R₀", "the initial recovered population", Unit("persons", nomath), 0.0, Uniform(0, 4)),
-  Initial(:R₀, ExpressionFormula("R₀", nomath)), 
-
-  ])
-
-amr₁ = ASKEModel(header,
-  model,
-  [ode]
-)
-
-amr₂ = ASKEModel(header,
-  model,
-  [odelist]
-)
-
-println()
-println(amr_to_string(amr₁))
-println(amr_to_string(amr₂))
 end # module end

--- a/src/julia/amr_examples.jl
+++ b/src/julia/amr_examples.jl
@@ -103,4 +103,21 @@ println()
 println(amr_to_string(amr₁))
 println()
 println(amr_to_string(amr₂))
+# function sexp(amr)
+#   @match amr begin
+#     x::Number   => x
+#     s::String   => s
+#     s::Symbol   => s
+
+
+
+#   end
+# end
+AMR.amr_to_expr(amr₂.header) |> println
+AMR.amr_to_expr(amr₂.model) |> println
+map(AMR.amr_to_expr(amr₂.semantics[1]).args[2].args) do s; println(s) end
+AMR.amr_to_expr(amr₂.semantics[1]).args[2]
+AMR.amr_to_expr(amr₂.semantics[1])
+AMR.amr_to_expr(amr₂) |> println
+AMR.amr_to_expr(amr₁) |> println
 end

--- a/src/julia/amr_examples.jl
+++ b/src/julia/amr_examples.jl
@@ -61,9 +61,42 @@ amr₁ = ASKEModel(header,
   [ode]
 )
 
+typesystem = acsetspec(:(LabelledPetriNet{Symbol}), quote
+  S(label=:Pop)
+
+  T(label=:inf)
+  T(label=:disease)
+  T(label=:strata)
+
+  I(is=:Pop, it=:inf)
+  I(is=:Pop, it=:inf)
+  I(is=:Pop, it=:disease)
+  I(is=:Pop, it=:strata)
+
+  O(os=:Pop, it=:inf)
+  O(os=:Pop, it=:inf)
+  O(os=:Pop, it=:disease)
+  O(os=:Pop, it=:strata)
+end) 
+
+
+typing = Typing(
+  typesystem,
+  [
+    (:S=>:Pop),
+    (:I=>:Pop),
+    (:R=>:Pop),
+    (:inf=>:inf),
+    (:rec=>:disease)
+  ]
+)
+
 amr₂ = ASKEModel(header,
   model,
-  [odelist]
+  [
+    odelist,
+    typing
+  ]
 )
 
 println()

--- a/src/julia/amr_examples.jl
+++ b/src/julia/amr_examples.jl
@@ -1,0 +1,73 @@
+module AMRExamples
+include("amr.jl")
+using .AMR
+
+nomath = Math("")
+header = Header("SIR", "amr-schemas:petri_schema.json", "The SIR Model of disease", "petrinet", "0.2")
+model = acsetspec(:(LabelledPetriNet{Symbol}), quote
+  S(label=:S)
+  S(label=:I)
+  S(label=:R)
+
+  T(label=:inf)
+  T(label=:rec)
+
+  I(is=:S, it=:inf)
+  I(is=:I, it=:inf)
+  I(is=:I, it=:rec)
+
+  O(os=:I, it=:inf)
+  O(os=:I, it=:inf)
+  O(os=:R, it=:rec)
+end) 
+
+ode = ODERecord([Rate(:inf, ExpressionFormula( "S*I*β", nomath)),
+           Rate(:rec, ExpressionFormula("I*γ", nomath))],
+
+          [Initial(:S, ExpressionFormula("S₀", nomath)),
+           Initial(:I, ExpressionFormula("I₀", nomath)),
+           Initial(:R, ExpressionFormula("R₀", nomath)),],
+
+          [Parameter(:β, "β", "the beta parameter", Unit("1/(persons^2*day)", nomath), 1e-2, Uniform(1e-3, 2e-2)),
+          Parameter(:γ, "γ", "the gama parameter", Unit("1/(persons*day)", nomath), 3, Uniform(1, 2e+2)),
+
+          Parameter(:S₀, "S₀", "the initial susceptible population", Unit("persons", nomath), 300000000.0, Uniform(1e6, 4e6)),
+          Parameter(:I₀, "I₀", "the initial infected population", Unit("persons", nomath), 1.0, Uniform(1, 1)),
+          Parameter(:R₀, "R₀", "the initial recovered population", Unit("persons", nomath), 0.0, Uniform(0, 4)),
+          ],
+          Time(:t, Unit("day", nomath)))
+
+odelist = ODEList([
+  Time(:t, Unit("day", nomath)),
+  Parameter(:β, "β", "the beta parameter", Unit("1/(persons^2*day)", nomath), 1e-2, Uniform(1e-3, 2e-2)),
+  Rate(:inf, ExpressionFormula("S*I*β", nomath)),
+
+  Parameter(:γ, "γ", "the gama parameter", Unit("1/(persons*day)", nomath), 3, Uniform(1, 2e+2)),
+  Rate(:rec, ExpressionFormula("I*γ", nomath)), 
+
+  Parameter(:S₀, "S₀", "the initial susceptible population", Unit("persons", nomath), 300000000.0, Uniform(1e6, 4e6)),
+  Initial(:S₀, ExpressionFormula("S₀", nomath)),
+
+  Parameter(:I₀, "I₀", "the initial infected population", Unit("persons", nomath), 1.0, Uniform(1, 1)),
+  Initial(:I₀, ExpressionFormula("I₀", nomath)),
+
+  Parameter(:R₀, "R₀", "the initial recovered population", Unit("persons", nomath), 0.0, Uniform(0, 4)),
+  Initial(:R₀, ExpressionFormula("R₀", nomath)), 
+
+  ])
+
+amr₁ = ASKEModel(header,
+  model,
+  [ode]
+)
+
+amr₂ = ASKEModel(header,
+  model,
+  [odelist]
+)
+
+println()
+println(amr_to_string(amr₁))
+println()
+println(amr_to_string(amr₂))
+end

--- a/src/julia/amr_examples.jl
+++ b/src/julia/amr_examples.jl
@@ -1,6 +1,7 @@
 module AMRExamples
 include("amr.jl")
 using .AMR
+using Test
 
 nomath = Math("")
 header = Header("SIR", "amr-schemas:petri_schema.json", "The SIR Model of disease", "petrinet", "0.2")
@@ -111,4 +112,225 @@ map(AMR.amr_to_expr(amr₂.semantics[1]).args[2].args) do s; println(s) end
 AMR.amr_to_expr(amr₂.semantics[1]).args[2]
 AMR.amr_to_expr(amr₂.semantics[1])
 AMR.amr_to_expr(amr₂) |> println
+
+h = AMR.load(Header, Dict("name" => "SIR Model",
+"schema" => "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json",
+"description" => "SIR model",
+"schema_name" => "petrinet",
+"model_version" => "0.1"))  
+
+@test AMR.amr_to_string(h) == "\"\"\"\nASKE Model Representation: SIR Model0.1 :: petrinet \n   https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/petrinet_v0.5/petrinet/petrinet_schema.json\n\nSIR model\n\"\"\"" 
+
+mjson = raw"""{
+    "states": [
+      {
+        "id": "S",
+        "name": "Susceptible",
+        "description": "Number of individuals that are 'susceptible' to a disease infection",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000514"
+          }
+        },
+        "units": {
+          "expression": "person",
+          "expression_mathml": "<ci>person</ci>"
+        }
+      },
+      {
+        "id": "I",
+        "name": "Infected",
+        "description": "Number of individuals that are 'infected' by a disease",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000511"
+          }
+        },
+        "units": {
+          "expression": "person",
+          "expression_mathml": "<ci>person</ci>"
+        }
+      },
+      {
+        "id": "R",
+        "name": "Recovered",
+        "description": "Number of individuals that have 'recovered' from a disease infection",
+        "grounding": {
+          "identifiers": {
+            "ido": "0000592"
+          }
+        },
+        "units": {
+          "expression": "person",
+          "expression_mathml": "<ci>person</ci>"
+        }
+      }
+    ],
+    "transitions": [
+      {
+        "id": "inf",
+        "input": [
+          "S",
+          "I"
+        ],
+        "output": [
+          "I",
+          "I"
+        ],
+        "properties": {
+          "name": "Infection",
+          "description": "Infective process between individuals"
+        }
+      },
+      {
+        "id": "rec",
+        "input": [
+          "I"
+        ],
+        "output": [
+          "R"
+        ],
+        "properties": {
+          "name": "Recovery",
+          "description": "Recovery process of a infected individual"
+        }
+      }
+    ]
+  }
+  """
+using JSON
+modeldict = JSON.parse(mjson)
+using ACSets.ADTs
+
+AMR.petrispec(modeldict) |> ACSets.ADTs.to_string |> println
+
+semantics_str = raw"""{
+  "ode": {
+    "rates": [
+      {
+        "target": "inf",
+        "expression": "S*I*beta",
+        "expression_mathml": "<apply><times/><ci>S</ci><ci>I</ci><ci>beta</ci></apply>"
+      },
+      {
+        "target": "rec",
+        "expression": "I*gamma",
+        "expression_mathml": "<apply><times/><ci>I</ci><ci>gamma</ci></apply>"
+      }
+    ],
+    "initials": [
+      {
+        "target": "S",
+        "expression": "S0",
+        "expression_mathml": "<ci>S0</ci>"
+      },
+      {
+        "target": "I",
+        "expression": "I0",
+        "expression_mathml": "<ci>I0</ci>"
+      },
+      {
+        "target": "R",
+        "expression": "R0",
+        "expression_mathml": "<ci>R0</ci>"
+      }
+    ],
+    "parameters": [
+      {
+        "id": "beta",
+        "name": "β",
+        "description": "infection rate",
+        "units": {
+          "expression": "1/(person*day)",
+          "expression_mathml": "<apply><divide/><cn>1</cn><apply><times/><ci>person</ci><ci>day</ci></apply></apply>"
+        },
+        "value": 2.7e-7,
+        "distribution": {
+          "type": "StandardUniform1",
+          "parameters": {
+            "minimum": 2.6e-7,
+            "maximum": 2.8e-7
+          }
+        }
+      },
+      {
+        "id": "gamma",
+        "name": "γ",
+        "description": "recovery rate",
+        "grounding": {
+          "identifiers": {
+            "askemo": "0000013"
+          }
+        },
+        "units": {
+          "expression": "1/day",
+          "expression_mathml": "<apply><divide/><cn>1</cn><ci>day</ci></apply>"
+        },
+        "value": 0.14,
+        "distribution": {
+          "type": "StandardUniform1",
+          "parameters": {
+            "minimum": 0.1,
+            "maximum": 0.18
+          }
+        }
+      },
+      {
+        "id": "S0",
+        "name": "S₀",
+        "description": "Total susceptible population at timestep 0",
+        "value": 1000
+      },
+      {
+        "id": "I0",
+        "name": "I₀",
+        "description": "Total infected population at timestep 0",
+        "value": 1
+      },
+      {
+        "id": "R0",
+        "name": "R₀",
+        "description": "Total recovered population at timestep 0",
+        "value": 0
+      }
+    ],
+    "observables": [
+      {
+        "id": "noninf",
+        "name": "Non-infectious",
+        "states": [
+          "S",
+          "R"
+        ],
+        "expression": "S+R",
+        "expression_mathml": "<apply><plus/><ci>S</ci><ci>R</ci></apply>"
+      }
+    ],
+    "time": {
+      "id": "t",
+      "units": {
+        "expression": "day",
+        "expression_mathml": "<ci>day</ci>"
+      }
+    }
+  }
+}
+"""
+semantics_dict = JSON.parse(semantics_str)
+@show semantics_dict
+
+AMR.load(ODERecord, semantics_dict["ode"]) |> AMR.amr_to_string |> println
+
+sirmodel_dict = JSON.parsefile(joinpath([@__DIR__, "..", "..", "petrinet", "examples", "sir.json"]))
+AMR.optload(AMRExamples.sirmodel_dict, ["model", :states], nothing) |> show
+sirmodel = AMR.load(ASKEModel, sirmodel_dict) 
+sirmodel |> AMR.amr_to_string |> println
+
+sirmodel_dict = JSON.parsefile(joinpath([@__DIR__, "..", "..", "petrinet", "examples", "sir_typed.json"]))
+semtyp = sirmodel_dict["semantics"]["typing"]
+
+sirmodel = AMR.load(Typing, semtyp) |> AMR.amr_to_string |> println
+
+sirmodel = AMR.load(ASKEModel, sirmodel_dict) 
+sirmodel |> AMR.amr_to_string |> println
 end

--- a/src/julia/amr_examples.jl
+++ b/src/julia/amr_examples.jl
@@ -103,21 +103,12 @@ println()
 println(amr_to_string(amr₁))
 println()
 println(amr_to_string(amr₂))
-# function sexp(amr)
-#   @match amr begin
-#     x::Number   => x
-#     s::String   => s
-#     s::Symbol   => s
 
-
-
-#   end
-# end
+AMR.amr_to_expr(amr₁) |> println
 AMR.amr_to_expr(amr₂.header) |> println
 AMR.amr_to_expr(amr₂.model) |> println
 map(AMR.amr_to_expr(amr₂.semantics[1]).args[2].args) do s; println(s) end
 AMR.amr_to_expr(amr₂.semantics[1]).args[2]
 AMR.amr_to_expr(amr₂.semantics[1])
 AMR.amr_to_expr(amr₂) |> println
-AMR.amr_to_expr(amr₁) |> println
 end


### PR DESCRIPTION
I partially formalized the AMR representation for Petri nets as an ADT with MLStyle.jl and created some examples. This should enable:

1. A consistent implementation of AMR between AlgebraicJulia and MTK
2. A consistent specification between Julia implementations and other languages ([Python 3.10](https://docs.python.org/3/whatsnew/3.10.html) has structural pattern matching)
3. A truly human readable syntax for models (see below)
4. Automated deserialization of models using [ACSet ADTs](https://github.com/AlgebraicJulia/ACSets.jl/pull/40)
5. Automated generation of JSON schemas from a more concise specification
 
I don't expect anyone to adopt this before the evaluation event, unless they want to.

The human readable model specification could be in a DSL like 

```julia
"""
ASKE Model Representation: SIR@v0.2 :: petrinet 
   amr-schemas:petri_schema.json

The SIR Model of disease
"""
Model = quote
LabelledPetriNet{Symbol} begin 
  S(label=:S)
  S(label=:I)
  S(label=:R)
  T(label=:inf)
  T(label=:rec)
  I(is=:S,it=:inf)
  I(is=:I,it=:inf)
  I(is=:I,it=:rec)
  O(os=:I,it=:inf)
  O(os=:I,it=:inf)
  O(os=:R,it=:rec)
 end
end

ODE Equations: begin
t::Time{day}


# β -- the beta parameter
β::Parameter{1/(persons^2*day)} = 0.01 ~ U(0.001,0.02)

inf::Rate = S*I*β

# γ -- the gama parameter
γ::Parameter{1/(persons*day)} = 3.0 ~ U(1,200.0)

rec::Rate = I*γ

# S₀ -- the initial susceptible population
S₀::Parameter{persons} = 3.0e8 ~ U(1.0e6,4.0e6)

S₀::Initial = S₀

# I₀ -- the initial infected population
I₀::Parameter{persons} = 1.0 ~ U(1,1)

I₀::Initial = I₀

# R₀ -- the initial recovered population
R₀::Parameter{persons} = 0.0 ~ U(0,4)

R₀::Initial = R₀
end
```

This example is based on Julia syntax (so that I can trick Julia's `Base.parse` into doing the first level of parsing for me), but we could also make a python version that is compatible with [Python ast module](https://docs.python.org/3.11/library/ast.html?highlight=ast#module-ast) or roll our own grammar from scratch.