### PR TITLE
Model Inventory utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 **/node_modules/
 /docs/_book
 .vscode/
+__pycache__
+*.egg
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "askem-model-representations"
+version = "0.0.1"
+readme = "README.md"
+requires-python = ">3.9"
+
+dependencies = [
+   "sympy",
+   "tabulate",
+   "pandas"
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[tool.setuptools]
+package-dir = {"askem_model_representations"="validation"}
+
+
+

--- a/validation/model_inventory.py
+++ b/validation/model_inventory.py
@@ -82,7 +82,6 @@ def rate_laws(amr: dict):
     result = {t: t in rate_targets for t in transitions}
     summary = all(result.values())
 
-    # -- For each rate law: Parse teh 'expression' with sympy, check that those variables exist in the AMR as a state or a parameter
     return summary, result
 
 
@@ -188,7 +187,7 @@ if __name__ == "__main__":
         "--format",
         choices=["txt", "json"],
         default="txt",
-        help="Output format.  'txt' for human-readable (requires pandas), 'json' for machine-parsed.",
+        help="Output format.  'txt' for human-readable or 'json'.",
     )
     args = parser.parse_args()
     summary = args.format == "txt"

--- a/validation/model_inventory.py
+++ b/validation/model_inventory.py
@@ -146,7 +146,18 @@ def observables(amr: dict):
     return summary, result
 
 
-def check_schema(source: Union[dict, Path, str], summary=False):
+def check_amr(source: Union[dict, Path, str], summary=False):
+    """Do a battery of testa against an AMR.
+
+    Args:
+        source (Union[dict, Path, str]): AMR data as JSON-like object
+                or file-path (string or Path)
+        summary (bool, optional): Produce details, or just a true/false
+                summary for each test? (Default false)
+
+    Returns:
+        JSON description of inventory resutls
+    """
     if isinstance(source, str):
         source = Path(source)
 
@@ -185,14 +196,14 @@ if __name__ == "__main__":
     parser.add_argument("files", nargs="+", type=Path, help="Files to parse")
     parser.add_argument(
         "--format",
-        choices=["txt", "json"],
+        choices=["txt", "json", "json-summary"],
         default="txt",
         help="Output format.  'txt' for human-readable or 'json'.",
     )
     args = parser.parse_args()
-    summary = args.format == "txt"
+    summary = args.format in ["txt", "json-summary"]
 
-    results = [check_schema(file, summary) for file in args.files]
+    results = [check_amr(file, summary) for file in args.files]
     if args.format == "txt":
         import pandas as pd
 

--- a/validation/model_inventory.py
+++ b/validation/model_inventory.py
@@ -205,7 +205,11 @@ if __name__ == "__main__":
 
     results = [check_amr(file, summary) for file in args.files]
     if args.format in ["html", "md"]:
-        import pandas as pd
+        try:
+            import pandas as pd
+        except:
+            print(f"To use {args.format}, pandas must be installed.")
+            raise
 
         errors = [e for e in results if "message" in e]
         cleaned = [e for e in results if "message" not in e]

--- a/validation/model_inventory.py
+++ b/validation/model_inventory.py
@@ -1,0 +1,176 @@
+# Check which components of AMRs are present, report!
+#
+# Some parts of an AMR are optional but required in specific use-contexts.
+# This is valuable as an AMR can be used in multiple contexts, some of which
+# may fill in additional information.  This script/module loads a schema
+# and inventories what is present.  (CLI can process more than one schema).
+
+from pathlib import Path
+from typing import Union
+import json
+
+
+def fetch_path(path, doc):
+    """Fetches a literal path from a json document.  (A named-key-descent)."""
+    for step in path:
+        try:
+            doc = doc[step]
+        except KeyError:
+            return None
+    return doc
+
+
+def count_falses(issues: list[str, bool]) -> Union[None, int]:
+    """How many falses in the dict valeus? (None if the dict is empty.)"""
+    if not issues or len(issues) == 0:
+        return None
+    return len(issues) - sum([*issues.values()])
+
+
+def count_not_empty(issues: list[str, any]) -> Union[None, int]:
+    """How many non-empty dict/list/sets in the dict values?
+    (None if the dict is empty.)
+    """
+    if not issues or len(issues) == 0:
+        return None
+    return len(issues) - sum([(v is None or len(v) == 0) for v in issues.values()])
+
+
+def size_largest(issues: list[str, any]) -> Union[None, int]:
+    """How many non-empty dict/list/sets in the dict values?
+    (None if the dict is empty.)
+    """
+    if not issues or len(issues) == 0:
+        return None
+    largest = sorted(issues.values(), key=len, reverse=True)[0]
+    return len(largest)
+
+
+def distributions(amr: dict, summary=False):
+    """
+    Checks if there each parameter has a distribution or a value
+    associated with it.
+    """
+
+    paths = [["semantics", "ode", "parameters"], ["semantics", "pde", "parameters"]]
+
+    def _test(entry):
+        return "value" in entry or "distriubution" in entry
+
+    issues = {}
+    for path in paths:
+        target = fetch_path(path, amr)
+        if target:
+            partial = {"/".join(path + [e["id"]]): _test(e) for e in target}
+            issues = {**issues, **partial}
+
+    if summary:
+        return count_falses(issues)
+    else:
+        return issues
+
+
+def rate_laws(amr: dict, summary: bool = False):
+    """Check that each transition has a rate-law semantic"""
+    paths = [["semantics", "ode", "rates"], ["semantics", "pde", "rates"]]
+
+    transitions = {e["id"] for e in fetch_path(["model", "transitions"], amr)}
+
+    issues = {}
+    for path in paths:
+        target = fetch_path(path, amr)
+        if target:
+            targets = [e["target"] for e in target]
+            missing = transitions - set(targets)
+            issues["/".join(path)] = missing
+
+    if summary:
+        return size_largest(issues)
+    else:
+        return issues
+
+
+def initial_values(amr: dict, summary: bool = False):
+    paths = [["semantics", "ode", "rates"], ["semantics", "pde", "rates"]]
+    states = {e["id"] for e in fetch_path(["model", "states"], amr)}
+
+    issues = {}
+    for path in paths:
+        target = fetch_path(path, amr)
+        if target:
+            targets = [e["target"] for e in target]
+            missing = states - set(targets)
+            issues["/".join(path)] = missing
+
+    if summary:
+        return size_largest(issues)
+    else:
+        return issues
+
+
+def observables(amr: dict, summary: bool = False):
+    """How many observables are there?"""
+    paths = [["semantics", "ode", "observables"], ["semantics", "pde", "observables"]]
+
+    found = {}
+    for path in paths:
+        target = fetch_path(path, amr)
+        p = "/".join(path)
+        found[p] = [t["id"] for t in target] if target else None
+
+    if summary:
+        return count_not_empty(found)
+    else:
+        return found
+
+
+def check_schema(source: Union[dict, Path, str], summary=False):
+    if isinstance(source, str):
+        source = Path(source)
+
+    if isinstance(source, Path):
+        source_id = source.name
+        with open(source) as f:
+            data = json.load(f)
+    else:
+        source_id = "<json>"
+        data = source
+
+    try:
+        return {
+            "source": source_id,
+            "distributions": distributions(data, summary),
+            "rate laws": rate_laws(data, summary),
+            "initial values": initial_values(data, summary),
+            "observables": observables(data, summary),
+        }
+    except Exception:
+        if source_id != "json":
+            source_id = str(source)
+        print(f"Error processing {source_id}")
+        return {"source": source_id}
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", nargs="+", type=Path, help="Files to parse")
+    parser.add_argument(
+        "--format",
+        choices=["txt", "json"],
+        default="txt",
+        help="Output format.  'txt' for human-readable (requires pandas), 'json' for machine-parsed.",
+    )
+    args = parser.parse_args()
+    summary = args.format == "txt"
+
+    results = [check_schema(file, summary) for file in args.files]
+    if args.format == "txt":
+        import pandas as pd
+
+        df = pd.DataFrame(results).set_index("source")
+        print("Summary of failures")
+        print(df.to_markdown())
+    else:
+        print(results)

--- a/validation/model_inventory.py
+++ b/validation/model_inventory.py
@@ -196,15 +196,15 @@ if __name__ == "__main__":
     parser.add_argument("files", nargs="+", type=Path, help="Files to parse")
     parser.add_argument(
         "--format",
-        choices=["txt", "json", "json-summary"],
-        default="txt",
-        help="Output format.  'txt' for human-readable or 'json'.",
+        choices=["md", "json", "html", "json-detail"],
+        default="md",
+        help="Output format.  (choose 'md' for human-readable in console).",
     )
     args = parser.parse_args()
-    summary = args.format in ["txt", "json-summary"]
+    summary = args.format != "json-detail"
 
     results = [check_amr(file, summary) for file in args.files]
-    if args.format == "txt":
+    if args.format in ["html", "md"]:
         import pandas as pd
 
         errors = [e for e in results if "message" in e]
@@ -212,7 +212,10 @@ if __name__ == "__main__":
 
         if len(cleaned) > 0:
             df = pd.DataFrame(cleaned).set_index("source")
-            print(df.to_markdown())
+            if args.format == "md":
+                print(df.to_markdown())
+            elif args.format == "html":
+                print(df.to_html())
 
         for error in errors:
             print(f"Error loading {error['source']}: {error['message']}")


### PR DESCRIPTION
Check what information an AMR contains, produce a report. 

Models kept in various repositories contain different information.  The utility included loads an AMR json description, parses its content and checks for key components (rate laws, initial values, etc.) that are required for down-stream use.  The utility can be pip-installed from github and be imported as a module in other projects ("from askem_model_representations import model_inventory").  

The utility can be run from the command line to check multiple files.  Results are output as HTML or markdown table summaries, json summary or a detailed json report.  

The ciemss team wants to use this in our own testing, but thought the utility itself may be of more service in this repo.


Summary of PR contents:
- Model checking module (including command-line interface)
- Python package metadata to support installation/use by other projects.
