### PR TITLE
Extend to load data from a URL, file or JSON. FIXES missed variables in rate laws

### DIFF
--- a/validation/model_inventory.py
+++ b/validation/model_inventory.py
@@ -111,7 +111,11 @@ def rate_law_parse(amr: dict):
         except Exception:
             return "Rate law expression invalid", f"Error parsing: {in_expr}"
 
-    defs = {str(s): s in vars.keys() for s in out_expr.free_symbols}
+    def _present(s, list):
+        return str(s) in vars.keys() or s in vars.keys()
+
+    defs = {str(s): _present(s, vars.keys()) for s in out_expr.free_symbols}
+
     return all(defs.values()), defs
 
 

--- a/validation/model_inventory.py
+++ b/validation/model_inventory.py
@@ -110,11 +110,7 @@ def rate_law_parse(amr: dict):
             out_expr = sympy.parse_expr(in_expr, local_dict=vars)
         except Exception:
             return "Rate law expression invalid", f"Error parsing: {in_expr}"
-
-    def _present(s, list):
-        return str(s) in vars.keys() or s in vars.keys()
-
-    defs = {str(s): _present(s, vars.keys()) for s in out_expr.free_symbols}
+    defs = {str(s): s in vars.values() for s in out_expr.free_symbols}
 
     return all(defs.values()), defs
 

--- a/validation/model_inventory.py
+++ b/validation/model_inventory.py
@@ -174,7 +174,7 @@ def check_amr(source: Union[dict, Path, str], summary=False):
     try:
         return {
             "source": source_id,
-            "parameter distribtuion exists": param_at_least_one_distribution(data)[
+            "parameter distribution exists": param_at_least_one_distribution(data)[
                 part
             ],
             "parameter dist/value set": param_distribution_or_value(data)[part],


### PR DESCRIPTION
Driving request was to be able to point the utility at a URL to load a JSON.  That has been added.

During testing for URL loading, we discovered that rate-law variable checks sometimes failed because a sympy *symbol* was compared to a *string*.  That error was also fixed.